### PR TITLE
set max_local_storage_nodes to 1

### DIFF
--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -87,7 +87,7 @@
 
 # By default, multiple nodes are allowed to start from the same installation location
 # to disable it, set the following:
-# node.max_local_storage_nodes: 1
+node.max_local_storage_nodes: 1
 
 
 #################################### Index ####################################


### PR DESCRIPTION
@dannyroberts - this will prevent the machine from accidentally booting multiple versions of elasticsearch