### PR TITLE
add newrelic.ini file

### DIFF
--- a/ansible/inventories/development
+++ b/ansible/inventories/development
@@ -1,5 +1,5 @@
 [webworkers]
-192.168.33.15
+192.168.33.15 newrelic_app_name=django
 
 [postgresql]
 192.168.33.16
@@ -17,7 +17,7 @@
 192.168.33.16
 
 [celery]
-192.168.33.16
+192.168.33.16 newrelic_app_name=celery
 
 [elasticsearch]
 192.168.33.16

--- a/ansible/roles/newrelic/tasks/main.yml
+++ b/ansible/roles/newrelic/tasks/main.yml
@@ -17,3 +17,11 @@
 
 - name: Make sure newrelic-sysmond has started
   service: name=newrelic-sysmond state=started
+
+- name: copy newrelic ini file
+  sudo_user: "{{ cchq_user }}"
+  template:
+    src: newrelic.ini.j2
+    dest: "{{ item }}/newrelic.ini"
+  with_items:
+    - "{{ www_home }}"

--- a/ansible/roles/newrelic/tasks/main.yml
+++ b/ansible/roles/newrelic/tasks/main.yml
@@ -25,3 +25,4 @@
     dest: "{{ item }}/newrelic.ini"
   with_items:
     - "{{ www_home }}"
+  when: newrelic_app_name is defined

--- a/ansible/roles/newrelic/templates/newrelic.ini.j2
+++ b/ansible/roles/newrelic/templates/newrelic.ini.j2
@@ -1,0 +1,234 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+license_key = {{ NEW_RELIC_KEY }}
+
+# The appplication name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+app_name = CommCare HQ
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+#log_file = /tmp/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP protocol. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Tells the transaction tracer and error collector (when
+# enabled) whether or not to capture the query string for the
+# URL and send it as the request parameters for display in the
+# UI. When "true", it is still possible to exclude specific
+# values from being captured using the "ignored_params" setting.
+capture_params = false
+
+# Space separated list of variables that should be removed from
+# the query string captured for display as the request
+# parameters in the UI.
+ignored_params =
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace = couchdbkit.client:Database.open_doc
+                                    couchdbkit.client:Database.get
+                                    couchdbkit.client:Database.bulk_save
+                                    couchdbkit.client:Database.save_doc
+                                    couchdbkit.client:Database.save_docs
+                                    couchdbkit.client:Database.delete_docs
+                                    couchdbkit.client:Database.bulk_delete
+                                    couchdbkit.client:Database.delete_doc
+                                    couchdbkit.client:Database.raw_view
+                                    couchdbkit.client:Database.put_attachment
+                                    couchdbkit.client:Database.delete_attachment
+                                    couchdbkit.client:Database.fetch_attachment
+                                    corehq.apps.hqwebapp.templatetags.hq_shared_tags:_toggle_enabled
+                                    casexml.apps.phone.restore:RestoreConfig.get_stock_payload
+                                    casexml.apps.phone.restore:RestoreConfig._get_case_payload
+                                    casexml.apps.phone.restore:RestoreConfig._get_case_payload_batched
+                                    couchforms.util:process_xform
+                                    casexml.apps.case.xform:process_cases_with_casedb
+                                    corehq.apps.commtrack.processing:process_stock
+                                    casexml.apps.phone.xml:get_case_element
+                                    jsonobject.base:JsonObjectBase.wrap
+                                    jsonobject.base:JsonObjectBase.validate
+                                    jsonobject.base:JsonObjectBase.to_json
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors = celery.exceptions:RetryTaskError
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = [staging] CommCare HQ ({{ inventory_hostname }})
+monitor_mode = false
+
+[newrelic:production]
+app_name = [production] CommCare HQ ({{ inventory_hostname }})
+monitor_mode = true
+log_file = {{ log_home }}/newrelic-python-agent.log
+
+# ---------------------------------------------------------------------------

--- a/ansible/roles/newrelic/templates/newrelic.ini.j2
+++ b/ansible/roles/newrelic/templates/newrelic.ini.j2
@@ -223,11 +223,11 @@ monitor_mode = false
 monitor_mode = false
 
 [newrelic:staging]
-app_name = [staging] CommCare HQ ({{ inventory_hostname }})
+app_name = [staging] CommCare HQ ({{ newrelic_app_name }})
 monitor_mode = false
 
 [newrelic:production]
-app_name = [production] CommCare HQ ({{ inventory_hostname }})
+app_name = [production] CommCare HQ ({{ newrelic_app_name }})
 monitor_mode = true
 log_file = {{ log_home }}/newrelic-python-agent.log
 


### PR DESCRIPTION
@dannyroberts @TylerSheffels 

Not 100% sure this is the best way to do this but thought I'd give it a go. Setup should be as follows:

Each machine that is running a python process which reports to NewRelic has a `newrelic.ini` file in the `www_home` folder. The contents of the files are basically the same except for the name which should vary according to host function e.g. celery, django, pillowtop.