### PR TITLE
Restore payload tasks

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -7,6 +7,7 @@ log_home: "{{ www_home }}/log"
 service_home: "{{ cchq_home }}/services"
 virtualenv_home: "{{ www_home }}/python_env"
 virtualenv_preindex_home: "{{ www_home }}/python_env_preindex"
+restore_payload_dir: "{{ www_home }}/data/restore_payloads"
 
 cchq_user: cchq
 dev_group: dev

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -214,6 +214,8 @@ SOIL_DEFAULT_CACHE = "redis"
 
 REPORT_CACHE = 'redis'
 
+RESTORE_PAYLOAD_DIR = {{ restore_payload_dir }}
+
 memcached = {
     'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
     'LOCATION': '{{ localsettings.MEMCACHED_HOST }}:{{ localsettings.MEMCACHED_PORT }}',

--- a/ansible/roles/webworker/tasks/main.yml
+++ b/ansible/roles/webworker/tasks/main.yml
@@ -1,5 +1,14 @@
 # Tasks to be run on machines running django
 
+- name: create restore payloads directory
+  sudo: yes
+  file:
+    path: "{{ restore_payload_dir }}"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0755
+    state: directory
+
 - name: Create payload purging cron job
   sudo: yes
   cron:

--- a/ansible/roles/webworker/vars/main.yml
+++ b/ansible/roles/webworker/vars/main.yml
@@ -1,1 +1,0 @@
-restore_payload_dir: "{{ code_home }}/restore_payloads"


### PR DESCRIPTION
This smells bad to me, but I couldn't figure out a better way to do this. I'm trying to accomplish two things: one, setup the `restore_payloads` directory and a cron job to periodically clean the dir; two, fill the `RESTORE_PAYLOAD_DIR` variable in localsettings template. Originally I had the `restore_payload_dir` variable in the `webworker` role and that worked fine, but since the localsettings template is under the `commcarehq` role, i can't access that variable. I didn't want to declare the variable twice and couldn't figure out a way to share variables between roles. The reason this works for touchforms is that the task of creating the directory is in the same role as creating the localsettings file. This solution just declares a global `restore_payload_dir` variable, but that seems like overkill. let me know if you have a better solution @dannyroberts @TylerSheffels 