### PR TITLE
Refactor nfs

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -8,6 +8,7 @@ service_home: "{{ cchq_home }}/services"
 virtualenv_home: "{{ www_home }}/python_env"
 virtualenv_preindex_home: "{{ www_home }}/python_env_preindex"
 
+shared_dir_gid: 1500  # This GID cannot already be allocated
 shared_mount_dir: "/mnt/shared_data"
 restore_payload_dir: "{{ shared_mount_dir }}/restore_payloads"
 

--- a/ansible/roles/shared_dir/tasks/setup_host.yml
+++ b/ansible/roles/shared_dir/tasks/setup_host.yml
@@ -15,7 +15,7 @@
   sudo: yes
   lineinfile:
     dest: /etc/exports
-    line: "{{ shared_data_dir }} {{ item }}(rw,sync,no_subtree_check,anongid={{ shared_dir_gid }})"
+    line: "{{ shared_data_dir }} {{ item }}(rw,sync,all_squash,no_subtree_check,anongid={{ shared_dir_gid }})"
     regexp: "^{{ shared_data_dir }} {{ item }}"
     state: present
   with_items: groups.webworkers

--- a/ansible/roles/shared_dir/tasks/setup_host.yml
+++ b/ansible/roles/shared_dir/tasks/setup_host.yml
@@ -6,7 +6,7 @@
     path: "{{ shared_data_dir }}"
     owner: "nobody"
     group: "{{ shared_dir_gid }}"
-    mode: 0775
+    mode: "u=rwx,g=rwx,o=r"
     state: directory
   tags:
     - nfs

--- a/ansible/roles/webworker/tasks/main.yml
+++ b/ansible/roles/webworker/tasks/main.yml
@@ -6,7 +6,7 @@
   file:
     path: "{{ restore_payload_dir }}"
     owner: "nobody"
-    group: "nogroup"
+    group: "{{ shared_dir_gid }}"
     mode: "u=rwx,g=rwx,o=r"
     state: directory
   tags:

--- a/ansible/roles/webworker/tasks/main.yml
+++ b/ansible/roles/webworker/tasks/main.yml
@@ -7,7 +7,7 @@
     path: "{{ restore_payload_dir }}"
     owner: "nobody"
     group: "nogroup"
-    mode: 0755
+    mode: "u=rwx,g=rwx,o=r"
     state: directory
   tags:
     - restore


### PR DESCRIPTION
@dannyroberts 

This does a couple things. The dir permissions are pretty obvious. The other thing is `all_squash`.  This `all_squash` makes things work. Not in the most ideal way though. `all_squash` - "Convert incoming requests, from ALL users, to the anonymous uid and gid.". Unfortunately nfs does not have an option that says "Convert requests, from SOME users, to the anonymous uid and gid." So if we don't want to have to write as root, we have to allow every user on the machine to write to the shared dir. I tried really hard to make this work in such a way that only `cchq` could write the files, but short of syncing all the uids on all the servers, I think it's impossible. Here's a quote from one of the trouble shooting [guides](http://nfs.sourceforge.net/nfs-howto/ar01s07.html) I read:

"If you cannot have a single uid for all instances of a username, suboptimal steps must be taken. In some instances you could make the directory and files world-readable, thereby enabling all users to read it. It could also be made world-writeable, but that's always a bad idea. It could be mounted all_squash with a specific anonuid and/or a specific anongid to cure the problem, but once again, at least from the NFS viewpoint, that's equivalent to making it world readable or writeable."

Why it was working before:
Not quite sure, but I think I changed the permissions using root at one point and made the shared directory owned by the users on the staging webworkers.