### PR TITLE
Postgres conf hostnames

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,2 +1,4 @@
 ansible==1.9.0.1
+netaddr
+dnspython
 passlib

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,2 +1,2 @@
-ansible==1.8.2
+ansible==1.9.0.1
 passlib

--- a/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -101,11 +101,17 @@ host    all             all             ::1/128                 md5
 #local   replication     postgres                                peer
 #host    replication     postgres        127.0.0.1/32            md5
 #host    replication     postgres        ::1/128                 md5
+hostssl    all      devreadonly            0.0.0.0/0       md5
 
 # host all all 192.168.33.0/24 md5
 
 {% for host in (groups['touchforms'] + groups['webworkers'] + groups['celery'] + groups['pillowtop'] + groups['postgresql']) | unique %}
-{% for db in postgresql_dbs %}
-host   {{ db }}   {{ localsettings.PG_DATABASE_USER }}   {{ host }}/32   md5
+{% for db in postgresql_dbs | unique %}
+{% if host | ipaddr %}
+hostssl   {{ db }}	{{ localsettings.PG_DATABASE_USER }}	{{ host }}/32   md5
+{% else %}
+# {{ host }}
+hostssl   {{ db }}	{{ localsettings.PG_DATABASE_USER }}	{{ lookup('dig', host, wantlist=True)[0] }}/32	md5
+{% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
@dannyroberts this allows ansible to lookup the IP address of a hostname. Requires the version bump in ansible.

Other changes:
- Change `host` to `hostssl` (this is what we use in our prod environment)
- Allow access to postgres via devreadonly user (also used in prod environment)

The domain lookup was tested using my Vagrant machine