### PR TITLE
leave shared_buffers at default value

### DIFF
--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -110,7 +110,7 @@ ssl = true              # (change requires restart)
 
 # - Memory -
 
-shared_buffers = 1024MB           # min 128kB
+#shared_buffers = 1024MB           # min 128kB
                     # (change requires restart)
 #temp_buffers = 8MB         # min 800kB
 #max_prepared_transactions = 0      # zero disables the feature


### PR DESCRIPTION
@benrudolph 

Was getting this error after the conf changes:

```
IpcMemoryCreate: shmget(key=5432001, size=415776768, 03600) failed: Invalid argument 

This error usually means that PostgreSQL's request for a shared memory 
segment exceeded your kernel's SHMMAX parameter. You can either 
reduce the request size or reconfigure the kernel with larger SHMMAX. 
To reduce the request size (currently 415776768 bytes), reduce 
PostgreSQL's shared_buffers parameter (currently 50000) and/or 
its max_connections parameter (currently 12).
```

@sravfeyn buddy ping