### PR TITLE
add deploy_buildservers.yml for stripped-down env

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,11 @@ Note: to generate this list automatically, you can run something like
 ansible-playbook -u root -i ../../commcare-hq/fab/inventory/india deploy_stack.yml -e "@../config/india/india.yml" --tags= | sed 's/ERROR: tag(s) not found in playbook: .  possible values: //g' | sed 's/,/\
 /g' | xargs -I% echo - %
 ```
+
+
+### Provisioning build servers (experimental)
+
+For a stripped down setup that's only enough to run the test suite, use the following:
+```bash
+ansible-playbook -i ../buildservers deploy_buildservers.yml --skip-tags=node_installs
+```

--- a/ansible/deploy_buildservers.yml
+++ b/ansible/deploy_buildservers.yml
@@ -1,0 +1,30 @@
+- name: update apt cache
+  hosts: buildserver
+  gather_facts: no
+  sudo: yes
+  tasks:
+    - apt: update_cache=true cache_valid_time=3600
+
+- name: Common Installs
+  hosts: buildserver
+  sudo: yes
+  roles:
+    - common_installs
+
+- name: Postgresql
+  hosts: buildserver
+  sudo: yes
+  roles:
+    - {role: postgresql, skip_configure: yes}
+
+- name: Couchdb
+  hosts: buildserver
+  sudo: yes
+  roles:
+    - {role: couchdb, skip_configure: yes}
+
+- name: Redis
+  hosts: buildserver
+  sudo: yes
+  roles:
+    - bennojoy.redis

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -20,3 +20,6 @@ cchq_user: cchq
 dev_group: dev
 
 django_port: 9010
+
+# used for stripped down couchdb and postgres installs
+skip_configure: no

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -34,15 +34,21 @@
   with_items:
     - less@1.3.1
     - n@1.3.0
+  tags:
+    - node_installs
 
 - name: Update Node
   command: 'n 0.10.29'
   sudo: yes
+  tags:
+    - node_installs
 
 - name: Install lessc from source
   sudo: yes
   # this is lessc 1.7.3
   git: repo='https://github.com/less/less.js' dest='/opt/lessc' version='546bedd3' recursive=yes accept_hostkey=yes depth=1
+  tags:
+    - node_installs
 
 - name: Install pip packages
   pip: name={{ item }}

--- a/ansible/roles/couchdb/tasks/configure.yml
+++ b/ansible/roles/couchdb/tasks/configure.yml
@@ -1,0 +1,10 @@
+- name: Apply CouchDB config
+  template: src=local.ini.j2 dest=/usr/local/etc/couchdb/local.ini
+
+- include: 'service.yml'
+
+- name: Add CouchDB databases
+  shell: "{{ item }}"
+  with_items:
+    - curl -X PUT "http://{{ localsettings.COUCH_SERVER_ROOT }}/{{ localsettings.COUCH_DATABASE_NAME }}"
+    - curl -X PUT "http://{{ localsettings.COUCH_SERVER_ROOT }}/_config/admins/{{ localsettings.COUCH_USERNAME }}" -d '"{{ localsettings.COUCH_PASSWORD }}"'

--- a/ansible/roles/couchdb/tasks/main.yml
+++ b/ansible/roles/couchdb/tasks/main.yml
@@ -38,9 +38,6 @@
 - name: Add CouchDB user
   user: name=couchdb createhome=no password=no state=present
 
-- name: Apply CouchDB config
-  template: src=local.ini.j2 dest=/usr/local/etc/couchdb/local.ini
-
 - name: CouchDB ownership permissions
   file: path={{ item }} owner=couchdb group=couchdb recurse=yes state=directory
   with_items:
@@ -49,17 +46,10 @@
     - /usr/local/var/run/couchdb
     - /usr/local/etc/couchdb/
 
-- name: Configure CouchDB as service
-  file: src=/usr/local/etc/init.d/couchdb dest=/etc/init.d/couchdb state=link
+- include: 'configure.yml'
+  when: not skip_configure
 
-- name: Update rc.d
-  shell: update-rc.d couchdb defaults
+- include: 'service.yml'
+  when: skip_configure
 
-- name: Start CouchDB service
-  service: name=couchdb state=started
 
-- name: Add CouchDB databases
-  shell: "{{ item }}"
-  with_items:
-    - curl -X PUT "http://{{ localsettings.COUCH_SERVER_ROOT }}/{{ localsettings.COUCH_DATABASE_NAME }}"
-    - curl -X PUT "http://{{ localsettings.COUCH_SERVER_ROOT }}/_config/admins/{{ localsettings.COUCH_USERNAME }}" -d '"{{ localsettings.COUCH_PASSWORD }}"'

--- a/ansible/roles/couchdb/tasks/service.yml
+++ b/ansible/roles/couchdb/tasks/service.yml
@@ -1,0 +1,8 @@
+- name: Configure CouchDB as service
+  file: src=/usr/local/etc/init.d/couchdb dest=/etc/init.d/couchdb state=link
+
+- name: Update rc.d
+  shell: update-rc.d couchdb defaults
+
+- name: Start CouchDB service
+  service: name=couchdb state=started

--- a/ansible/roles/postgresql/tasks/configure.yml
+++ b/ansible/roles/postgresql/tasks/configure.yml
@@ -1,0 +1,60 @@
+- name: Check for original postgresql directory
+  stat: path="{{ postgresql_dir_original_path }}"
+  register: orig_path
+  when: pg_install == True
+
+- name: Check for new postgresql directory
+  stat: path="{{ postgresql_dir_path }}"
+  register: new_path
+  when: pg_install == True
+
+- name: Assert postgresql directory shows up in exactly one place
+  fail: msg="postgresl directory must either be {{ postgresql_dir_path }} or {{ postgresql_dir_original_path }} (and not both)"
+  when: >
+    pg_install == True and
+    ((orig_path.stat.exists and new_path.stat.exists) or (not orig_path.stat.exists and not new_path.stat.exists))
+
+- name: Move postgres to encrypted drive
+  command: "mv {{ postgresql_dir_original_path }} {{ postgresql_dir_path }}"
+  when: pg_install == True and orig_path.stat.exists
+
+- name: generate en_US.UTF-8 locale
+  locale_gen: name='en_US.UTF-8' state=present
+  when:
+    pg_install == True
+
+- name: PostgreSQL app configuration
+  sudo_user: postgres
+  template: src=postgresql.conf.j2 dest={{ postgresql_config_home }}/postgresql.conf
+  register: postgresql_configuration_updated
+
+- name: PostgreSQL access configuration
+  sudo_user: postgres
+  template: src=pg_hba.conf.j2 dest={{ postgresql_config_home }}/pg_hba.conf
+  register: postgresql_access_updated
+
+- name: start postgresql
+  sudo_user: postgres
+  service: name=postgresql state=started
+
+- name: Apply PostgreSQL configuration changes
+  sudo_user: postgres
+  service: name=postgresql state=restarted
+  when: postgresql_configuration_updated.changed or postgresql_access_updated.changed
+
+- name: Create PostgreSQL databases
+  sudo_user: postgres
+  postgresql_db: name={{ item }} state=present
+  with_items: postgresql_dbs
+  when:
+    pg_install == True
+
+- name: Create PostgreSQL users
+  sudo_user: postgres
+  postgresql_user:
+    name: "{{ localsettings.PG_DATABASE_USER }}"
+    password: "{{ localsettings.PG_DATABASE_PASSWORD }}"
+    role_attr_flags: CREATEDB
+    state: present
+  when:
+    pg_install == True

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -10,63 +10,8 @@
   when:
     pg_install == True
 
-- name: Check for original postgresql directory
-  stat: path="{{ postgresql_dir_original_path }}"
-  register: orig_path
-  when: pg_install == True
+- include: 'configure.yml'
+  when: not skip_configure
 
-- name: Check for new postgresql directory
-  stat: path="{{ postgresql_dir_path }}"
-  register: new_path
-  when: pg_install == True
-
-- name: Assert postgresql directory shows up in exactly one place
-  fail: msg="postgresl directory must either be {{ postgresql_dir_path }} or {{ postgresql_dir_original_path }} (and not both)"
-  when: >
-    pg_install == True and
-    ((orig_path.stat.exists and new_path.stat.exists) or (not orig_path.stat.exists and not new_path.stat.exists))
-
-- name: Move postgres to encrypted drive
-  command: "mv {{ postgresql_dir_original_path }} {{ postgresql_dir_path }}"
-  when: pg_install == True and orig_path.stat.exists
-
-- name: generate en_US.UTF-8 locale
-  locale_gen: name='en_US.UTF-8' state=present
-  when:
-    pg_install == True
-
-- name: PostgreSQL app configuration
-  sudo_user: postgres
-  template: src=postgresql.conf.j2 dest={{ postgresql_config_home }}/postgresql.conf
-  register: postgresql_configuration_updated
-
-- name: PostgreSQL access configuration
-  sudo_user: postgres
-  template: src=pg_hba.conf.j2 dest={{ postgresql_config_home }}/pg_hba.conf
-  register: postgresql_access_updated
-
-- name: start postgresql
-  sudo_user: postgres
-  service: name=postgresql state=started
-
-- name: Apply PostgreSQL configuration changes
-  sudo_user: postgres
-  service: name=postgresql state=restarted
-  when: postgresql_configuration_updated.changed or postgresql_access_updated.changed
-
-- name: Create PostgreSQL databases
-  sudo_user: postgres
-  postgresql_db: name={{ item }} state=present
-  with_items: postgresql_dbs
-  when:
-    pg_install == True
-
-- name: Create PostgreSQL users
-  sudo_user: postgres
-  postgresql_user:
-    name: "{{ localsettings.PG_DATABASE_USER }}"
-    password: "{{ localsettings.PG_DATABASE_PASSWORD }}"
-    role_attr_flags: CREATEDB
-    state: present
-  when:
-    pg_install == True
+- include: 'simple-setup.yml'
+  when: skip_configure

--- a/ansible/roles/postgresql/tasks/simple-setup.yml
+++ b/ansible/roles/postgresql/tasks/simple-setup.yml
@@ -1,0 +1,16 @@
+- name: Create postgres user
+  user: name=postgres state=present
+
+- name: Create PostgreSQL users
+  sudo_user: postgres
+  postgresql_user:
+    name: "postgres"
+    password: ''
+    role_attr_flags: CREATEDB
+    state: present
+  when: skip_configure
+
+- name: start postgresql
+  sudo_user: postgres
+  service: name=postgresql state=started
+  when: skip_configure


### PR DESCRIPTION
for running unit tests on a remote server

- split out couchdb tasks
- split out postgresql tasks

This is from my PID yesterday, thought I'd at least get it reviewed now