### PR TITLE
fix india http redirect issue

### DIFF
--- a/ansible/roles/apache2/templates/cchq.j2
+++ b/ansible/roles/apache2/templates/cchq.j2
@@ -54,6 +54,7 @@
     ProxyPass / balancer://hqcluster/
     ProxyPassReverse / balancer://hqcluster/
     ServerName {{ SITE_HOST }}
+    Header edit Location ^http: https:
 
     ## This directive is causing trouble in my local development tests because
     ## it always gets hit before the proxy pass has a chance to work correctly.


### PR DESCRIPTION
Ask me not why this works on www, for I do not know. This fixes it on india.

This keeps apache from rewriting the Location header (that django sends back on a redirect) to use http