### PR TITLE
define FORMPLAYER_LOG_FILE

### DIFF
--- a/ansible/roles/touchforms/templates/localsettings.py.j2
+++ b/ansible/roles/touchforms/templates/localsettings.py.j2
@@ -1,5 +1,11 @@
+#
+# {{ ansible_managed }}
+#
+import os
+
 URL_ROOT = "https://{{ SITE_HOST }}/a/{{ '{{' }}DOMAIN{{ '}}' }}"
 PERSISTENCE_DIRECTORY = "{{ touchforms_data_dir }}"
+FORMPLAYER_LOG_FILE = os.path.join('{{ log_home }}','log',"formplayer.clean-{{ localsettings.DEPLOY_MACHINE_NAME }}.log")
 
 {% if fake_ssl_cert %}
 from jython_ssl import SSLContext, TRUST_ALL_CONTEXT


### PR DESCRIPTION
@esoergel 
fyi @snopoke 

tested this out on vagrant. example output:
```
+#
+# Ansible managed: /vagrant/ansible/roles/touchforms/templates/localsettings.py.j2 modified on 2015-05-19 20:17:46 by vagrant on control
+#
+import os
+
+URL_ROOT = "https://192.168.33.17/a/{{DOMAIN}}"
+PERSISTENCE_DIRECTORY = "/home/cchq/www/dev/data/touchforms"
+FORMPLAYER_LOG_FILE = os.path.join('/home/cchq/www/dev/log','log',"formplayer.clean-192.168.33.16.log")
+
+from jython_ssl import SSLContext, TRUST_ALL_CONTEXT
+SSLContext.setDefault(TRUST_ALL_CONTEXT)
```

see: https://github.com/dimagi/touchforms/pull/116