### PR TITLE
Add dhis site to nginx proxy

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -15,4 +15,5 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_static == True, action: site, site_name: commtrack_static }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.hq_status == True, action: site, site_name: hq_status }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.tableau == True, action: site, site_name: tableau }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.dhis == True, action: site, site_name: dhis }
     - { role: nginx, when: proxy_type == 'nginx', action: restart }

--- a/ansible/roles/nginx/vars/dhis.yml
+++ b/ansible/roles/nginx/vars/dhis.yml
@@ -1,0 +1,11 @@
+---
+nginx_sites:
+- server:
+   file_name: dhis
+   listen: "443 ssl"
+   # Move these to a localsetting?
+   server_name: dhis-test.commcarehq.org
+   location1:
+    name: /
+    proxy_pass: http://dhis1.internal.commcarehq.org
+


### PR DESCRIPTION
This exposes dhis over nginx.  Should be merged before the actual nginx proxy switch.