### PR TITLE
Revert "Quote variable"

### DIFF
--- a/ansible/roles/touchforms/templates/localsettings.py.j2
+++ b/ansible/roles/touchforms/templates/localsettings.py.j2
@@ -13,8 +13,8 @@ SSLContext.setDefault(TRUST_ALL_CONTEXT)
 {% endif %}
 
 ### REDIS CONFIG ###
-REDIS_HOST = '{{ localsettings.REDIS_HOST }}'
-REDIS_PORT = '{{ localsettings.REDIS_PORT }}'
+REDIS_HOST = {{ localsettings.REDIS_HOST }}
+REDIS_PORT = {{ localsettings.REDIS_PORT }}
 ### END REDIS CONFIG ###
 
 


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#128

@benrudolph this needs to be an int. Was getting this error on staging:

```
Traceback (most recent call last):
  File "/home/cchq/www/staging/code_root/submodules/touchforms-src/touchforms/backend/xformserver.py", line 298, in <module>
    main(
  File "/home/cchq/www/staging/code_root/submodules/touchforms-src/touchforms/backend/xformserver.py", line 272, in main
    xformplayer._init(init_gui())
  File "/home/cchq/www/staging/code_root/submodules/touchforms-src/touchforms/backend/xformplayer.py", line 109, in _init
    global_state = GlobalStateManager(ctx)
  File "/home/cchq/www/staging/code_root/submodules/touchforms-src/touchforms/backend/xformplayer.py", line 60, in __init__
    self.redis = Jedis(settings.REDIS_HOST, settings.REDIS_PORT)
TypeError: redis.clients.jedis.Jedis(): 2nd arg can't be coerced to int
```