### PR TITLE
Update tags for touchforms localsettings

### DIFF
--- a/ansible/roles/touchforms/tasks/main.yml
+++ b/ansible/roles/touchforms/tasks/main.yml
@@ -17,6 +17,8 @@
     group: cchq
     owner: cchq
     mode: 0644
+  tags:
+    - tf-localsettings
 
 - name: create touchforms data directory
   sudo: yes


### PR DESCRIPTION
@czue @TylerSheffels this is a pretty common operation and i think it makes sense to formally add a tag so i can stop tagging it manually on salt