### PR TITLE
Nginx tweaks4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ansible/roles/bennojoy.redis"]
 	path = ansible/roles/bennojoy.redis
 	url = https://github.com/bennojoy/redis.git
+[submodule "ansible/roles/ansible-logrotate"]
+	path = ansible/roles/ansible-logrotate
+	url = git@github.com:nickhammond/ansible-logrotate.git

--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -15,9 +15,11 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http_redirect == True, action: site, site_name: cchq_http_redirect }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.hq_status == True, action: site, site_name: hq_status }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.tableau == True, action: site, site_name: tableau }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.tableau == True, action: site, site_name: tableau_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.dhis == True, action: site, site_name: dhis }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.dhis == True, action: site, site_name: dhis_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.wiki == True, action: site, site_name: wiki }
-    - { role: nginx, when: proxy_type == 'nginx' and active_sites.wiki_http == True, action: site, site_name: wiki_http }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.wiki == True, action: site, site_name: wiki_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_ssl == True, action: site, site_name: commtrack_ssl }
     # Don't put any .commcarehq.org ssl configurations below commtrack, the ssl cert variable that gets loaded persists between roles
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_http == True, action: site, site_name: commtrack_http }
@@ -30,3 +32,4 @@
       when: run_newrelic_plugin_agent
   tags:
     - newrelic-plugin-agent
+

--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -8,7 +8,6 @@
     - { role: apache2, when: proxy_type == 'apache2' }
     - { role: nginx, when: proxy_type == 'nginx', action: install }
     - { role: nginx, when: proxy_type == 'nginx', action: site, site_name: cchq_ssl }
-    - { role: nginx, when: proxy_type == 'nginx', action: site, site_name: cchq }
     - { role: nginx, when: proxy_type == 'nginx', action: errorpages }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_redirect == True, action: site, site_name: cchq_redirect }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http == True, action: site, site_name: cchq_http }
@@ -33,3 +32,20 @@
   tags:
     - newrelic-plugin-agent
 
+- name: Nginx log rolling configurations
+  hosts: proxy
+  roles:
+    - role: ansible-logrotate
+      logrotate_scripts:
+        - name: "{{ deploy_env }}"
+          path: "{{ log_home }}/*.log"
+          options:
+            - monthly
+            - size 1G
+            - rotate 14
+            - missingok
+            - compress
+            - delaycompress
+            - copytruncate
+            - nocreate
+            - notifempty

--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -7,6 +7,7 @@ nginx_sites:
    client_max_body_size: 100m
    use_balancer: True
    proxy_set_header: "Host $http_host"
+   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     use_balancer: True
@@ -17,7 +18,10 @@ nginx_sites:
     name: "/static"
     alias: "{{ nginx_static_home }}"
     try_files: "$uri $uri/index.html $uri/ =404"
-   location5:
+   location3:
     name: "/{{ transfer_payload_dir_name }}"
     alias: "{{ transfer_payload_dir }}"
     is_internal: True
+   location4:
+    name: /errors
+    alias: "{{ errors_home }}/pages"

--- a/ansible/roles/nginx/vars/commtrack_ssl.yml
+++ b/ansible/roles/nginx/vars/commtrack_ssl.yml
@@ -6,7 +6,7 @@ nginx_sites:
 - server:
    file_name: zz_commtrack #There was a bug where a phone would default to connecting to commtrack on login and use this cert, then failing.  Renaming the file makes it load later and work.
    listen: "443 ssl"
-   server_name: "{{ COMMTRACK_SITE_HOST }}"
+   server_name: "{{ COMMTRACK_SITE_HOST }} www.{{ COMMTRACK_SITE_HOST }}"
    client_max_body_size: 100m
    use_balancer: True
    proxy_set_header: "Host $http_host"

--- a/ansible/roles/nginx/vars/dhis.yml
+++ b/ansible/roles/nginx/vars/dhis.yml
@@ -5,6 +5,10 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: dhis-test.commcarehq.org
+   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     proxy_pass: http://dhis1.internal.commcarehq.org:8080
+   location2:
+    name: /errors
+    alias: "{{ errors_home }}/pages"

--- a/ansible/roles/nginx/vars/dhis.yml
+++ b/ansible/roles/nginx/vars/dhis.yml
@@ -7,5 +7,4 @@ nginx_sites:
    server_name: dhis-test.commcarehq.org
    location1:
     name: /
-    proxy_pass: http://dhis1.internal.commcarehq.org
-
+    proxy_pass: http://dhis1.internal.commcarehq.org:8080

--- a/ansible/roles/nginx/vars/dhis_http.yml
+++ b/ansible/roles/nginx/vars/dhis_http.yml
@@ -1,0 +1,11 @@
+---
+# Send anything from http -> https
+nginx_sites:
+- server:
+   file_name: "dhis_http"
+   listen: "80"
+   server_name: "dhis-test.commcarehq.org"
+   proxy_set_header: "Host $http_host"
+   location1:
+    name: /
+    return: "301 https://$server_name"

--- a/ansible/roles/nginx/vars/sentry.yml
+++ b/ansible/roles/nginx/vars/sentry.yml
@@ -5,6 +5,10 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: sentry.commcarehq.org
+   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     proxy_pass: http://logs.internal.dimagi.com:9000
+   location2:
+    name: /errors
+    alias: "{{ errors_home }}/pages"

--- a/ansible/roles/nginx/vars/sentry.yml
+++ b/ansible/roles/nginx/vars/sentry.yml
@@ -1,0 +1,10 @@
+---
+nginx_sites:
+- server:
+   file_name: sentry
+   listen: "443 ssl"
+   # Move these to a localsetting?
+   server_name: sentry.commcarehq.org
+   location1:
+    name: /
+    proxy_pass: http://logs.internal.dimagi.com:9000

--- a/ansible/roles/nginx/vars/tableau.yml
+++ b/ansible/roles/nginx/vars/tableau.yml
@@ -5,6 +5,10 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: tableau.commcarehq.org
+   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     proxy_pass: http://tableau1.internal.commcarehq.org
+   location2:
+    name: /errors
+    alias: "{{ errors_home }}/pages"

--- a/ansible/roles/nginx/vars/tableau_http.yml
+++ b/ansible/roles/nginx/vars/tableau_http.yml
@@ -1,0 +1,11 @@
+---
+# Send anything from http -> https
+nginx_sites:
+- server:
+   file_name: "tableau_http"
+   listen: "80"
+   server_name: "tableau.commcarehq.org"
+   proxy_set_header: "Host $http_host"
+   location1:
+    name: /
+    return: "301 https://$server_name"

--- a/ansible/roles/nginx/vars/wiki.yml
+++ b/ansible/roles/nginx/vars/wiki.yml
@@ -8,7 +8,7 @@ nginx_sites:
    error_page: "502 503 /errors/50x.html"
    location1:
     name: /
-    proxy_pass: http://confluence.dimagi.com
+    proxy_pass: https://confluence.internal.dimagi.com
    location2:
     name: "= /"
     return: "302 https://$server_name/display/commcarepublic/Home"

--- a/ansible/roles/nginx/vars/wiki.yml
+++ b/ansible/roles/nginx/vars/wiki.yml
@@ -4,9 +4,14 @@ nginx_sites:
    file_name: wiki
    listen: "443 ssl"
    server_name: "wiki.commcarehq.org help.commcarehq.org"
+   proxy_set_header: "Host $http_host"
+   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     proxy_pass: http://confluence.dimagi.com
    location2:
     name: "= /"
     return: "302 https://$server_name/display/commcarepublic/Home"
+   location3:
+    name: /errors
+    alias: "{{ errors_home }}/pages"

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -13,6 +13,7 @@ active_sites:
   hq_status: False
   tableau: False
   dhis: False
+  wiki: False
 
 
 deploy_env: dev
@@ -25,7 +26,7 @@ dev_users:
   absent: []
 
 # use this value to switch between nginx and apache
-proxy_type: apache2
+proxy_type: nginx
 
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '128m'


### PR DESCRIPTION
This adds a few things:
* Handling for www.commtrack.org with the correct certificate
* Correct dhis not specifying the correct internal port
* Adds log rotating for site specific nginx logs
* Adds back in 502+503 error pages that I dropped in a rebase
* Adds an endpoint for sentry
* Adds handling for dhis and tableau redirection from http -> https

@dannyroberts 
@snopoke buddy