### PR TITLE
Set proxy headers for Tableau

### DIFF
--- a/ansible/roles/nginx/vars/tableau.yml
+++ b/ansible/roles/nginx/vars/tableau.yml
@@ -6,6 +6,11 @@ nginx_sites:
    # Move these to a localsetting?
    server_name: tableau.commcarehq.org
    error_page: "502 503 /errors/50x.html"
+   proxy_set_headers:
+   - "Host $http_host"
+   - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Proto $scheme"
+   - "X-Forwarded-Host $host:443"
    location1:
     name: /
     proxy_pass: http://tableau1.internal.commcarehq.org


### PR DESCRIPTION
Without these headers Tableau Server tries to guess the server name.