### PR TITLE
Adding timing log back

### DIFF
--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -10,6 +10,7 @@ nginx_sites:
    - "Host $http_host"
    - "X-Forwarded-For $remote_addr"
    error_page: "502 503 /errors/50x.html"
+   access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    location1:
     name: /
     use_balancer: True


### PR DESCRIPTION
@dannyroberts @czue 

Even though new relic has this same data, I would like to have it in the nginx logs in order to look at things like requests per hour, or timing at a particular time of day.  @snopoke let me know if there is a better way/new relic does this already.