### PR TITLE
Add read timeout for tableau

### DIFF
--- a/ansible/roles/nginx/vars/tableau.yml
+++ b/ansible/roles/nginx/vars/tableau.yml
@@ -14,6 +14,7 @@ nginx_sites:
    location1:
     name: /
     proxy_pass: http://tableau1.internal.commcarehq.org
+    proxy_read_timeout: 120s
    location2:
     name: /errors
     alias: "{{ errors_home }}/pages"


### PR DESCRIPTION
@dannyroberts @czue 

This value is how long nginx waits for a response from the downstream server. I am on the fence for increasing it across the board, because I think its good to see what services are taking more than a minute to return.  If want to do that we would need a way to see 504 in the nginx logs, does that sound worth doing? 