### PR TITLE
set redis timeout to 300

### DIFF
--- a/ansible/roles/bennojoy.redis/templates/redis.conf.j2
+++ b/ansible/roles/bennojoy.redis/templates/redis.conf.j2
@@ -37,7 +37,7 @@ bind {{ redis_bind_address }}
 # unixsocketperm 755
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # Set server verbosity to 'debug'
 # it can be one of:


### PR DESCRIPTION
decided 300 was a perfectly good redis timeout across infrastructures
we can parameterize this later if we ever need to, but didn't seem worth the effort