### PR TITLE
Revert "reduce timeout"

### DIFF
--- a/ansible/roles/bennojoy.redis/templates/redis.conf.j2
+++ b/ansible/roles/bennojoy.redis/templates/redis.conf.j2
@@ -37,7 +37,7 @@ bind {{ redis_bind_address }}
 # unixsocketperm 755
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 60
+timeout 300
 
 # Set server verbosity to 'debug'
 # it can be one of:


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#169

after further debugging we now no longer suspect this is necessary