### PR TITLE
use the redis-server pid file consistent with init.d script

### DIFF
--- a/ansible/roles/bennojoy.redis/templates/redis.conf.j2
+++ b/ansible/roles/bennojoy.redis/templates/redis.conf.j2
@@ -18,7 +18,7 @@ daemonize yes
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile /var/run/redis/redis.pid
+pidfile /var/run/redis/redis-server.pid
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.


### PR DESCRIPTION
@benrudolph 

