### PR TITLE
Update redis.conf

### DIFF
--- a/ansible/roles/redis/defaults/main.yml
+++ b/ansible/roles/redis/defaults/main.yml
@@ -16,7 +16,7 @@ redis_db_dir: /var/lib/redis
 redis_role: master
 redis_requirepass: false
 redis_pass: None
-redis_max_clients: 128
+redis_max_clients: 10000
 redis_max_memory: 512mb
 redis_maxmemory_policy: volatile-lru
 redis_appendfsync: everysec

--- a/ansible/roles/redis/templates/redis.conf.j2
+++ b/ansible/roles/redis/templates/redis.conf.j2
@@ -344,23 +344,3 @@ slowlog-log-slower-than 10000
 # There is no limit to this length. Just be aware that it will consume memory.
 # You can reclaim memory used by the slow log with SLOWLOG RESET.
 slowlog-max-len 1024
-
-
-############################### ADVANCED CONFIG ###############################
-
-{% if ansible_distribution == 'RedHat' %}
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
-hash-max-zipmap-entries 512
-hash-max-zipmap-value 64
-list-max-ziplist-entries 512
-list-max-ziplist-value 64
-set-max-intset-entries 512
-zset-max-ziplist-entries 128
-zset-max-ziplist-value 64
-activerehashing yes
-{% endif %}
-
-
-
-


### PR DESCRIPTION
@snopoke most everything seems g2g. been using this to check settings and read about them: http://download.redis.io/redis-stable/redis.conf. in version 2.6 redis has the ability to automatically set maxclients. if we specify 10000 and the OS can't handle that many clients that redis will automatically change the maxclients setting to what it can handle. thus i think it's best to leave it at 10000 and let redis figure it out. this seems to be the number that is used in most examples too. here's more info: http://redis.io/topics/clients#maximum-number-of-clients

fyi @orangejenny, @dannyroberts 