### PR TITLE
Pin version to 3.0

### DIFF
--- a/ansible/roles/redis/vars/main.yml
+++ b/ansible/roles/redis/vars/main.yml
@@ -8,6 +8,4 @@ env:
 
 redis_ubuntu_pkg:
   - python-selinux
-  - redis-server
-
-  
+  - redis-server=3:3.0.*


### PR DESCRIPTION
@snopoke @dannyroberts this is needed in order for ansible to actually upgrade the redis version. this is in effect on staging

@orangejenny 