### PR TITLE
least_conn load balance

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -4,8 +4,9 @@
 
 {% if item.server.get('use_balancer', False) == True %}
 upstream {{ item.server.file_name }} {
+  least_conn;
 {% for host in groups['webworkers'] %}
-  server {{ host }}:{{ django_port }} weight=2;
+  server {{ host }}:{{ django_port }};
 {% endfor %}
 }
 {% endif %}


### PR DESCRIPTION
@TylerSheffels was looking into the `OSError: [Errno 12] Cannot allocate memory` error we occasionally get. This ends up coming from us not being able to allocate enough space to run the `form_translate.jar`. I was looking at newrelic and our webworkers aren't that evenly balanced. hqdjango5 was maxed out in memory while hqdjango3 was only using 50%. I'm wondering if you think using a different load balancing schema will work better? was reading about it here: http://nginx.org/en/docs/http/load_balancing.html

buddy: @snopoke 