### PR TITLE
install npm instead of nodejs

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -27,7 +27,7 @@
     - htop
     - tmpreaper
     - mailutils
-    - nodejs
+    - npm
     - at
     - screen
     - gettext


### PR DESCRIPTION
npm seems to install node, not the other way around