### PR TITLE
Commtrack purely redirects to commcare, and the supply anchor now, so…

### DIFF
--- a/ansible/roles/nginx/vars/commtrack_ssl.yml
+++ b/ansible/roles/nginx/vars/commtrack_ssl.yml
@@ -8,7 +8,6 @@ nginx_sites:
    listen: "443 ssl"
    server_name: "{{ COMMTRACK_SITE_HOST }} www.{{ COMMTRACK_SITE_HOST }}"
    client_max_body_size: 100m
-   use_balancer: True
    proxy_set_header: "Host $http_host"
    location1:
     name: /


### PR DESCRIPTION
… this is unused

@benrudolph 