### PR TITLE
HSTS config

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -55,6 +55,9 @@ server {
 {% if nginx_ssl_ciphers|default('') %}
   ssl_ciphers {{ nginx_ssl_ciphers }};
 {% endif %}
+{% if nginx_hsts_max_age %}
+  add_header Strict-Transport-Security "max-age={{ nginx_hsts_max_age }}";
+{% endif %}
 {% endif %}
 
 {% if server_tokens|default('off') %}

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -46,7 +46,7 @@ elasticsearch_cluster_name: 'prodhqes-1.x'
 
 nofile_limit: 65536
 
-nginx_hsts_max_age: 86400 # 1 day
+nginx_hsts_max_age: 300 # 5 minutes
 
 # commcarehq.org of certs
 nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -46,6 +46,8 @@ elasticsearch_cluster_name: 'prodhqes-1.x'
 
 nofile_limit: 65536
 
+nginx_hsts_max_age: 86400 # 1 day
+
 # commcarehq.org of certs
 nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
 nginx_key_value: '{{ ssl_secrets.private_keys.commcarehq_org }}'


### PR DESCRIPTION
This PR adds HSTS (HSTS - a response header that tells browser that HQ is HTTPS only). This is not only a good security practice but also cuts rountrip cost of HTTP -> HTTPS redirect, as modern browsers will then automatically request HTTPS even when user enters an HTTP URL (see note on [this PR](https://github.com/dimagi/commcare-hq/pull/8076) about redirect time). But I have few questions before getting this merged in.
- Do we serve any HTTP traffic at all?
- Is 2 months expiry too high or too low?
- Should we include all subdomains as well?
