### PR TITLE
install python-netaddr on the controller

### DIFF
--- a/provisioning/control.sh
+++ b/provisioning/control.sh
@@ -1,5 +1,6 @@
 sudo apt-get update
 sudo apt-get install -y python-software-properties
+sudo apt-get install -y python-netaddr
 sudo apt-add-repository ppa:ansible/ansible
 sudo apt-get update
 sudo apt-get install -y ansible


### PR DESCRIPTION
@dannyroberts i was getting this error setting up postgres.

`fatal: [192.168.33.16] => {'msg': 'AnsibleFilterError: The ipaddr filter requires python-netaddr be installed on the ansible controller', 'failed': True}`

running this command on the controller fixes it, but I wasn't 100% sure this was the right way to make sure that happens.
