### PR TITLE
don't install multiple versions of postgres

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -21,7 +21,6 @@
 - name: Install PostgreSQL & dependencies
   apt: name={{ item }} state=present
   with_items:
-    - postgresql
     - postgresql-{{ postgresql_version }}
     - libpq-dev
     - python-psycopg2


### PR DESCRIPTION
@benrudolph not sure if this is the right thing to do or not.

however as it currently works it installs both 9.4 and 9.1 and then fails trying to start them both up because there's a port conflict. 