### PR TITLE
enable supervisor http iface

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -645,3 +645,9 @@ BANK_ROUTING_NUMBER_ACH = '{{ localsettings.BANK_ROUTING_NUMBER_ACH }}'
 BANK_ROUTING_NUMBER_WIRE = '{{ localsettings.BANK_ROUTING_NUMBER_WIRE }}'
 
 ENABLE_PRELOGIN_SITE = True
+
+{% if supervisor_http_enabled|default(false) %}
+SUPERVISOR_RPC_ENABLED = True
+SUPERVISOR_USERNAME = '{{ supervisor_http_username }}'
+SUPERVISOR_PASSWORD = '{{ supervisor_http_password }}'
+{% endif %}

--- a/ansible/roles/supervisor/templates/supervisord.conf.j2
+++ b/ansible/roles/supervisor/templates/supervisord.conf.j2
@@ -11,10 +11,12 @@ file=/tmp/supervisor.sock   ; (the path to the socket file)
 ;username=user              ; (default is no username (open server))
 ;password=123               ; (default is no password (open server))
 
-;[inet_http_server]         ; inet (TCP) server disabled by default
-;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
+{% if supervisor_http_enabled|default(false) %}
+[inet_http_server]         ; inet (TCP) server disabled by default
+port=*:9001                ; (ip_address:port specifier, *:port for all iface)
+username={{ supervisor_http_username }}              ; (default is no username (open server))
+password={{ supervisor_http_password }}               ; (default is no password (open server))
+{% endif %}
 
 [supervisord]
 logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -60,6 +60,10 @@ postgres_config:
   pgb_pool_timeout: 2
   pgb_pool_mode: session
 
+supervisor_http_enabled: True
+supervisor_http_username: user
+supervisor_http_password: 123
+
 localsettings:
   ALLOWED_HOSTS:
     - localhost


### PR DESCRIPTION
@czue @dannyroberts @TylerSheffels 

What do you think about enabling the web interface for supervisor which would make it possible to start / stop services via the HQ system console (using XML-RPC)? I'm thinking of the pillows.