### PR TITLE
Gzip all of the things

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -25,6 +25,21 @@ http {
 
         gzip on;
         gzip_disable "msie6";
+        gzip_types
+            text/html
+            text/css
+            text/javascript
+            text/xml
+            text/plain
+            text/x-component
+            application/javascript
+            application/json
+            application/xml
+            application/rss+xml
+            font/truetype
+            font/opentype
+            application/vnd.ms-fontobject
+            image/svg+xml;
 
         include /etc/nginx/conf.d/*.conf;
         include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
Right now we only gzip `text/html`. I expect performance gains if we gzip css and js as well. I came across this optimization potential while preparing for the performance session for the upcoming summit. Hold off on merge because I haven't actually tested this yet. 