### PR TITLE
Revert "add locmem cache to localsettings"

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -385,7 +385,6 @@ else:
 CACHES = {
     'default': redis_cache,
     'redis': redis_cache,
-    'locmem': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
 }
 
 ELASTICSEARCH_HOST = '{{ localsettings.ELASTICSEARCH_HOST }}'


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#211

Not necessary if we merge https://github.com/dimagi/commcare-hq/pull/8233 now, since it adds this in settings.py