### PR TITLE
Fix pg rotation

### DIFF
--- a/ansible/deploy_db.yml
+++ b/ansible/deploy_db.yml
@@ -56,20 +56,3 @@
       when: run_newrelic_plugin_agent
   tags:
     - newrelic-plugin-agent
-
-- name: Postgres log rolling configurations
-  hosts: postgresql
-  vars_files:
-    - roles/postgresql/defaults/main.yml
-  roles:
-    - role: ansible-logrotate
-      logrotate_scripts:
-        - name: "postgresql_{{ deploy_env }}"
-          path: "{{ postgresql_dir_path }}/{{ postgresql_version }}/main/pg_log/*"
-          options:
-            - daily
-            - rotate 30
-            - missingok
-            - compress
-            - delaycompress
-            - notifempty

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -295,11 +295,11 @@ logging_collector = on        # Enable capturing of stderr and csvlog
 # These are only used if logging_collector is on:
 log_directory = 'pg_log'       # directory where log files are written,
                     # can be absolute or relative to PGDATA
-log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'    # log file name pattern,
+log_filename = 'postgresql-%a.log'    # log file name pattern,
                     # can include strftime() escapes
 #log_file_mode = 0600           # creation mode for log files,
                     # begin with 0 to use octal notation
-#log_truncate_on_rotation = off     # If on, an existing log file with the
+log_truncate_on_rotation = on     # If on, an existing log file with the
                     # same name as the new log file will be
                     # truncated rather than appended to.
                     # But such truncation only occurs on
@@ -309,7 +309,7 @@ log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'    # log file name pattern,
                     # in all cases.
 log_rotation_age = 1d          # Automatic rotation of logfiles will
                     # happen after that time.  0 disables.
-log_rotation_size = 10MB       # Automatic rotation of logfiles will
+log_rotation_size = 0       # Automatic rotation of logfiles will
                     # happen after that much log output.
                     # 0 disables.
 


### PR DESCRIPTION
@snopoke don't think the rotation was working quite how i planned. it ended up creating a bunch more files with `1`s appended at the end. i.e.:
```
<filename>.1.1
<filename>.1
<filename>
```
this is an alternative that keeps 1 weeks worth of logs