### PR TITLE
A few fixups for the datadog parser

### DIFF
--- a/ansible/roles/datadog/templates/datadog.conf.j2
+++ b/ansible/roles/datadog/templates/datadog.conf.j2
@@ -15,6 +15,6 @@ gce_updated_hostname: yes
 # DEPRECATED: use conf.d/disk.yaml instead to configure it
 use_mount: no
 
-{% if inventory_host in groups['proxy'] %}
-dogstreams: {{ log_home }}/{{ deploy_env }}-timing.log:{{ datadog_parsers_dest }}/nginx/timings:parse_nginx_timings
+{% if inventory_hostname in groups['proxy'] %}
+dogstreams: {{ log_home }}/{{ deploy_env }}-timing.log:{{ datadog_parsers_dest }}/nginx/timings.py:parse_nginx_timings
 {% endif %}


### PR DESCRIPTION
@snopoke i deployed this and here were a few changes i had to make. it's unclear to me whether or not it's working. i can't find the metric yet in datadoghq. i'd imagine it'd be under `nginx.timings` since that what i called it [here](https://github.com/dimagi/datadog-parsers/pull/1/files#diff-04f4e797004c16d4737c308c9202e55cR28). are there datadog log files that you know i could check out see what's happening?