### PR TITLE
Don't create log dir

### DIFF
--- a/ansible/roles/nginx/tasks/install.yml
+++ b/ansible/roles/nginx/tasks/install.yml
@@ -13,11 +13,6 @@
   user: name={{ nginx_user }} createhome=no password=no state=present groups="{{ cchq_user }}"
   when: nginx_install == True
 
-- name: Create nginx logfile home
-  sudo: yes
-  file: path={{ log_home }} owner={{ cchq_user }} group={{ cchq_user }} mode=0770 state=directory
-  when: nginx_install == True
-
 - name: Create static files home
   sudo: yes
   file: path={{ nginx_static_home }} owner={{ cchq_user }} group={{ cchq_user }} mode=0755 state=directory


### PR DESCRIPTION
@czue @TylerSheffels this looks to be the culprit for the changing log dir permissions. we don't need to do this cause we already create the `log_home` in common with different permissions: https://github.com/dimagi/commcarehq-ansible/blob/nginx-log-dir-fix/ansible/roles/commcarehq/tasks/main.yml#L15

cc: @proteusvacuum 