### PR TITLE
install ntp on all machines

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -36,6 +36,7 @@
     - htop
     - tmpreaper
     - mailutils
+    - ntp
     - nodejs
     - at
     - screen


### PR DESCRIPTION
the root cause of http://manage.dimagi.com/default.asp?186591 is that the clocks are out of sync on the machines by more than 10 minutes. yuck.

also verified that older machines (e.g. hqdb0) have ntp installed properly, but newer ones (e.g. hqdjango12) do not. 

I didn't run deploy_common because i was worried about side effects so just manually updated india. I *think* that prod might be fine because rackspace might handle it a level above our vms (?)