### PR TITLE
Apache wants site configs to end in ".conf"

### DIFF
--- a/ansible/roles/apache2/tasks/main.yml
+++ b/ansible/roles/apache2/tasks/main.yml
@@ -82,7 +82,7 @@
 
 - name: Add sites
   sudo: yes
-  template: src={{ item }}.j2 dest=/etc/apache2/sites-available/{{ item }}
+  template: src={{ item }}.j2 dest=/etc/apache2/sites-available/{{ item }}.conf
   with_items:
     - cchq
     # TODO: Public site not funcitonal yet, but need the redirect from http -> https


### PR DESCRIPTION
fwiw, despite that we don't use Apache any more, @snopoke, cc @gcapalbo 

Without this change, a2ensite in the next step fails, because /usr/sbin/a2ensite doesn't recognise the file as a site config if it doesn't end in ".conf"
