### PR TITLE
Ansible user must sudo to add an apt repo

### DIFF
--- a/ansible/roles/nginx/tasks/install.yml
+++ b/ansible/roles/nginx/tasks/install.yml
@@ -1,5 +1,6 @@
 ---
 - name: Add nginx repository
+  sudo: yes
   apt_repository: repo='ppa:nginx/stable' state=present
 
 - name: Install nginx


### PR DESCRIPTION
Last change to Ansible tasks for a while, I hope. 

Small. @snopoke, cc @gcapalbo 