### PR TITLE
Reconfigure error pages to be generic for all nginx sites, add 400 page

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -41,6 +41,10 @@ server {
   {% endfor %}
 {% endfor %}
 
+{% for value in error_pages %}
+  error_page {{ value }};
+{% endfor %}
+
 {% for k,v in item.server.iteritems() if k.find('location') != -1 %}
   location {{ v.name }} {
     {% if v.get('use_balancer', False) == True %}

--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -10,7 +10,6 @@ nginx_sites:
    - "Host $http_host"
    - "X-Forwarded-For $remote_addr"
    add_header: "X-Frame-Options DENY"
-   error_page: "502 503 /errors/50x.html"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    location1:
     name: /

--- a/ansible/roles/nginx/vars/dhis.yml
+++ b/ansible/roles/nginx/vars/dhis.yml
@@ -5,7 +5,6 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: dhis-test.commcarehq.org
-   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     proxy_pass: http://dhis1.internal.commcarehq.org:8080

--- a/ansible/roles/nginx/vars/icds_tableau.yml
+++ b/ansible/roles/nginx/vars/icds_tableau.yml
@@ -5,7 +5,6 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: icds.commcarehq.org
-   error_page: "502 503 /errors/50x.html"
    proxy_set_headers:
    - "Host $http_host"
    - "X-Forwarded-For $remote_addr"

--- a/ansible/roles/nginx/vars/main.yml
+++ b/ansible/roles/nginx/vars/main.yml
@@ -30,3 +30,6 @@ nginx_separate_logs_per_site: True
 primary_ssl_env: ""
 commcarehq_errors_repository: "https://github.com/dimagi/commcare-hq-errorpages.git"
 errors_home: "{{ www_home }}/error_root"
+error_pages:
+  - "502 503 /errors/50x.html"
+  - "400 /errors/400.html"

--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -5,7 +5,6 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: endos-motech.commcarehq.org
-   error_page: "502 503 /errors/50x.html"
    proxy_set_headers:
    - "Host $http_host"
    - "X-Forwarded-For $remote_addr"

--- a/ansible/roles/nginx/vars/tableau.yml
+++ b/ansible/roles/nginx/vars/tableau.yml
@@ -5,7 +5,6 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: tableau.commcarehq.org
-   error_page: "502 503 /errors/50x.html"
    proxy_set_headers:
    - "Host $http_host"
    - "X-Forwarded-For $remote_addr"

--- a/ansible/roles/nginx/vars/wiki.yml
+++ b/ansible/roles/nginx/vars/wiki.yml
@@ -5,7 +5,6 @@ nginx_sites:
    listen: "443 ssl"
    server_name: "wiki.commcarehq.org help.commcarehq.org"
    proxy_set_header: "Host $http_host"
-   error_page: "502 503 /errors/50x.html"
    location1:
     name: /
     proxy_pass: https://confluence.internal.dimagi.com


### PR DESCRIPTION
This goes with https://github.com/dimagi/commcare-hq-errorpages/pull/5

After both PR's are merged we will need to run deploy_proxy on:
- [x] staging
- [ ] prod
- [ ] india
