### PR TITLE
Fix DHIS2 Reporting Correct Server URL on motech1/motech2

### DIFF
--- a/ansible/roles/nginx/vars/motech1.yml
+++ b/ansible/roles/nginx/vars/motech1.yml
@@ -5,6 +5,11 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: test-endos-motech.commcarehq.org
+   proxy_set_headers:
+   - "Host $http_host"
+   - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Proto $scheme"
+   - "X-Forwarded-Host $host:443"
    error_page: "502 503 /errors/50x.html"
    location1:
     name: /

--- a/ansible/roles/nginx/vars/motech2.yml
+++ b/ansible/roles/nginx/vars/motech2.yml
@@ -5,6 +5,11 @@ nginx_sites:
    listen: "443 ssl"
    # Move these to a localsetting?
    server_name: test-supply-motech.commcarehq.org
+   proxy_set_headers:
+   - "Host $http_host"
+   - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Proto $scheme"
+   - "X-Forwarded-Host $host:443"
    error_page: "502 503 /errors/50x.html"
    location1:
     name: /


### PR DESCRIPTION
@TylerSheffels I think this is the correct configuration.  I copied:
https://github.com/dimagi/commcarehq-ansible/blob/master/ansible/roles/nginx/vars/motech.yml