### PR TITLE
Secure Elasticsearch

### DIFF
--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 elasticsearch_version: 0.90.5
 elasticsearch_memory: 4096m
+elasticsearch_host: 127.0.0.1

--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 elasticsearch_version: 0.90.5
 elasticsearch_memory: 4096m
-elasticsearch_host: 127.0.0.1

--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -213,7 +213,6 @@ path.logs: /opt/data/elasticsearch/logs
 # Set both 'bind_host' and 'publish_host':
 #
 # network.host: 192.168.0.1
-network.host: {{ elasticsearch_host }}
 
 # Set a custom port for the node to node communication (9300 by default):
 #

--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -382,3 +382,11 @@ index.search.slowlog.threshold.query.trace: 500ms
 index.cache.field.max_size: 5000
 index.cache.field.expire: 10m
 index.cache.field.type: soft
+
+
+################################## Security ##################################
+
+# "...the issue with dynamic scripting is that it opens the full power of the JVM to execute arbitrary scripts."
+# -- https://www.elastic.co/blog/scripting-security
+
+script.disable_dynamic: true

--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -213,6 +213,7 @@ path.logs: /opt/data/elasticsearch/logs
 # Set both 'bind_host' and 'publish_host':
 #
 # network.host: 192.168.0.1
+network.host: {{ elasticsearch_host }}
 
 # Set a custom port for the node to node communication (9300 by default):
 #


### PR DESCRIPTION
**This is not tested.**

The new `elasticsearch_host` variable should be overridden in host-specific vars, and should be set to the internal IP address of the host. 

These changes are based on [Elasticsearch's blog post about the vulnerability](https://www.elastic.co/blog/scripting-security).

@czue, @snopoke, buddies @calellowitz, @sravfeyn 
