### PR TITLE
use ufw to restrict certain interfaces

### DIFF
--- a/ansible/deploy_common.yml
+++ b/ansible/deploy_common.yml
@@ -8,7 +8,7 @@
   hosts: '!proxy'
   sudo: yes
   roles:
-    - {role: ufw, tags: ufw, when: ufw_enabled and ufw_private_interface is defined}
+    - {role: ufw, tags: ufw, when: ufw_private_interface is defined}
 
 
 - name: Datadog agent

--- a/ansible/deploy_common.yml
+++ b/ansible/deploy_common.yml
@@ -4,6 +4,13 @@
   roles:
     - common
 
+- name: ufw (firewall)
+  hosts: '!proxy'
+  sudo: yes
+  roles:
+    - {role: ufw, tags: ufw, when: ufw_enabled and ufw_private_interface is defined}
+
+
 - name: Datadog agent
   hosts: all
   sudo: yes

--- a/ansible/deploy_common.yml
+++ b/ansible/deploy_common.yml
@@ -8,7 +8,7 @@
   hosts: '!proxy'
   sudo: yes
   roles:
-    - {role: ufw, tags: ufw, when: ufw_private_interface is defined}
+    - {role: ufw, tags: ufw, when: ufw_private_interface is defined and control_machine_ip is defined }
 
 
 - name: Datadog agent

--- a/ansible/roles/ufw/readme.md
+++ b/ansible/roles/ufw/readme.md
@@ -2,6 +2,6 @@
 
 This module configures a simple firewall rule using [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall).
 
-To enable it just specify `ufw_enabled: True` and add a `ufw_private_interface` (e.g. `eth0`) in your environment variables.
+To enable it just specify a `ufw_private_interface` (e.g. `eth0`) in your environment variables.
 If you do this, inbound traffic on _all interfaces except that one_ will be blocked.
 This includes ssh access so be careful in setting this up!

--- a/ansible/roles/ufw/readme.md
+++ b/ansible/roles/ufw/readme.md
@@ -2,6 +2,6 @@
 
 This module configures a simple firewall rule using [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall).
 
-To enable it just specify `ufw_private_interface` in your environment variables.
+To enable it just specify `ufw_enabled: True` and add a `ufw_private_interface` (e.g. `eth0`) in your environment variables.
 If you do this, inbound traffic on _all interfaces except that one_ will be blocked.
 This includes ssh access so be careful in setting this up!

--- a/ansible/roles/ufw/readme.md
+++ b/ansible/roles/ufw/readme.md
@@ -1,0 +1,7 @@
+# UFW Module
+
+This module configures a simple firewall rule using [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall).
+
+To enable it just specify `ufw_private_interface` in your environment variables.
+If you do this, inbound traffic on _all interfaces except that one_ will be blocked.
+This includes ssh access so be careful in setting this up!

--- a/ansible/roles/ufw/tasks/main.yml
+++ b/ansible/roles/ufw/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: default to denying all incoming traffic
+  ufw: policy=deny direction=incoming
+  when: ufw_enabled and ufw_private_interface is defined
+
+- name: allow incoming traffic on private interface
+  ufw: rule=allow direction=in interface={{ ufw_private_interface }}
+  when: ufw_enabled and ufw_private_interface is defined
+
+- name: turn on firewall
+  ufw: state=enabled
+  when: ufw_enabled and ufw_private_interface is defined

--- a/ansible/roles/ufw/tasks/main.yml
+++ b/ansible/roles/ufw/tasks/main.yml
@@ -1,6 +1,9 @@
 - name: allow incoming traffic on private interface
   ufw: rule=allow direction=in interface={{ ufw_private_interface }}
 
+- name: allow ssh traffic from control machine
+  ufw: rule=allow from={{ ansible_eth0.ipv4.address }}
+
 - name: default to denying all incoming traffic
   ufw: policy=deny direction=incoming
 

--- a/ansible/roles/ufw/tasks/main.yml
+++ b/ansible/roles/ufw/tasks/main.yml
@@ -1,11 +1,8 @@
 - name: allow incoming traffic on private interface
   ufw: rule=allow direction=in interface={{ ufw_private_interface }}
-  when: ufw_enabled and ufw_private_interface is defined
 
 - name: default to denying all incoming traffic
   ufw: policy=deny direction=incoming
-  when: ufw_enabled and ufw_private_interface is defined
 
 - name: turn on firewall
   ufw: state=enabled
-  when: ufw_enabled and ufw_private_interface is defined

--- a/ansible/roles/ufw/tasks/main.yml
+++ b/ansible/roles/ufw/tasks/main.yml
@@ -1,9 +1,9 @@
-- name: default to denying all incoming traffic
-  ufw: policy=deny direction=incoming
-  when: ufw_enabled and ufw_private_interface is defined
-
 - name: allow incoming traffic on private interface
   ufw: rule=allow direction=in interface={{ ufw_private_interface }}
+  when: ufw_enabled and ufw_private_interface is defined
+
+- name: default to denying all incoming traffic
+  ufw: policy=deny direction=incoming
   when: ufw_enabled and ufw_private_interface is defined
 
 - name: turn on firewall

--- a/ansible/roles/ufw/tasks/main.yml
+++ b/ansible/roles/ufw/tasks/main.yml
@@ -2,7 +2,7 @@
   ufw: rule=allow direction=in interface={{ ufw_private_interface }}
 
 - name: allow ssh traffic from control machine
-  ufw: rule=allow from={{ ansible_eth0.ipv4.address }}
+  ufw: rule=allow from={{ control_machine_ip }}
 
 - name: default to denying all incoming traffic
   ufw: policy=deny direction=incoming

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -39,9 +39,8 @@ elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '128m'
 elasticsearch_cluster_name: 'deves'
 
-# change to True to only allow access to eth1
-ufw_enabled: False
-ufw_private_interface: eth1
+# uncomment to only allow access to eth1
+# ufw_private_interface: eth1
 
 ECRYPTFS_PASSWORD: 'xxBvYiMZ3YVIVkFR'
 KSPLICE_ACTIVE: no

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -40,7 +40,11 @@ elasticsearch_memory: '128m'
 elasticsearch_cluster_name: 'deves'
 
 # uncomment to only allow access to eth1
-# ufw_private_interface: eth1
+#ufw_private_interface: eth1
+
+# uncomment and change to the control machine IP when using ufw
+# this ensures that ssh access from the control machine is always allowed regardless of other firewall rules
+#control_machine_ip: 127.0.0.1
 
 ECRYPTFS_PASSWORD: 'xxBvYiMZ3YVIVkFR'
 KSPLICE_ACTIVE: no

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -39,6 +39,10 @@ elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '128m'
 elasticsearch_cluster_name: 'deves'
 
+# change to True to only allow access to eth1
+ufw_enabled: False
+ufw_private_interface: eth1
+
 ECRYPTFS_PASSWORD: 'xxBvYiMZ3YVIVkFR'
 KSPLICE_ACTIVE: no
 KSPLICE_ACTIVATION_KEY:


### PR DESCRIPTION
@kaapstorm @snopoke this is deployed to softlayers and seems to be working well. rather than manually managing all our services to run on the right interfaces we can just disable all inbound traffic with a software firewall.