### PR TITLE
Add shared dir to pillowtop server

### DIFF
--- a/ansible/roles/shared_dir.yml
+++ b/ansible/roles/shared_dir.yml
@@ -10,7 +10,7 @@
     - include: shared_dir/tasks/setup_host.yml
 
 - name: SharedDirClient
-  hosts: webworkers:proxy:celery:shared_dir_host
+  hosts: webworkers:proxy:celery:pillowtop:shared_dir_host
   sudo: yes
   vars_files:
     - shared_dir/vars/main.yml

--- a/ansible/roles/shared_dir/tasks/setup_host.yml
+++ b/ansible/roles/shared_dir/tasks/setup_host.yml
@@ -22,6 +22,7 @@
     - groups.webworkers
     - groups.proxy
     - groups.celery
+    - groups.pillowtop
     - groups.shared_dir_host
   tags:
     - nfs


### PR DESCRIPTION
Fix `BlobDeletionPillow` failure:

`corehq.blobs.exceptions.Error: cannot initialize blob db: shared drive path is not a directory: '/mnt/shared_data'`

@dannyroberts @czue 