### PR TITLE
Add sudo to SSL cert commands when running ansible as not root user

### DIFF
--- a/ansible/roles/nginx/tasks/install.yml
+++ b/ansible/roles/nginx/tasks/install.yml
@@ -49,6 +49,7 @@
 
 
 - name: Copy cchq SSL cert
+  sudo: yes
   copy:
     src: "{{ nginx_combined_cert_file }}"
     dest: "{{ ssl_certs_dir }}/{{ nginx_ssl_cert }}"
@@ -60,6 +61,7 @@
     - update-cert
 
 - name: Copy cchq SSL Key
+  sudo: yes
   copy:
     src: "{{ apache2_key_file }}"
     dest: "{{ ssl_keys_dir }}/{{ nginx_ssl_key }}"
@@ -71,6 +73,7 @@
     - update-cert
 
 - name: Copy commtrack SSL cert
+  sudo: yes
   copy:
     src: "{{ commtrack_nginx_combined_cert_file }}"
     dest: "{{ ssl_certs_dir }}/{{ commtrack_nginx_ssl_cert }}"
@@ -80,6 +83,7 @@
   when: not fake_ssl_cert and commtrack_nginx_combined_cert_file is defined
 
 - name: Copy commtrack SSL Key
+  sudo: yes
   copy:
     src: "{{ commtrack_key_file }}"
     dest: "{{ ssl_keys_dir }}/{{ commtrack_nginx_ssl_key }}"


### PR DESCRIPTION
This was a confusing one for me. On softlayer we don't run ansible as root, we smartly run it as the ansible user. The ansible user is a member of the sudoers group, so it can run any command it needs to, but for commands that require elevated permissions we need to specify `sudo: yes` on the actual task. We probably didn't notice this before because other environments run as root.

cc: @orangejenny @benrudolph @dannyroberts 