### PR TITLE
pin npm to latest version

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -56,10 +56,11 @@
   command: 'npm config set registry http://registry.npmjs.org/'
   sudo: yes
 
-- name: Install npm lessc
+- name: Install npm items
   npm: name={{ item }} state=present global=yes
   sudo: yes
   with_items:
+    - npm@3.6.0
     - less@1.3.1
     - n@1.3.0
     - bower@1.5.3


### PR DESCRIPTION
Looks like we weren't specifying a version of npm before. I checked locally that `npm install -g npm@3.6.0` works.

@benrudolph