### PR TITLE
add cache-control header

### DIFF
--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -21,6 +21,7 @@ nginx_sites:
     name: "/static"
     alias: "{{ nginx_static_home }}"
     add_header: "Access-Control-Allow-Origin *"
+    expires: "1M"
     try_files: "$uri $uri/index.html $uri/ =404"
    location3:
     name: "/{{ transfer_payload_dir_name }}"


### PR DESCRIPTION
@dannyroberts did some reading on the cache control header. it's still a little unclear to me why our static files were being cached at all since we never added that header. i'm assuming it has to do with the fact that it was coming from the same origin. this allows any system to cache our static files, which i think is fine since anyone can access our static files from our site anyways.

this will cache for a month. we should start seeing this effect take place on staging over the next 24 hours when the amazon cloudfront cdn starts expiring static files. note the Cache-Control header
<img width="685" alt="screen shot 2016-02-29 at 3 14 30 pm" src="https://cloud.githubusercontent.com/assets/918514/13407650/915fba82-def7-11e5-9c83-87c100d07d19.png">
