### PR TITLE
adding port to psql address for ucr

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -26,7 +26,7 @@ SQL_REPORTING_OBJECT_OWNER = '{{ localsettings.REPORT_OBJECT_OWNER }}'
 {% endif %}
 
 {% if localsettings.get('UCR_DATABASE_NAME') %}
-UCR_DATABASE_URL = "postgresql://{{ localsettings.PG_DATABASE_USER }}:{{ localsettings.PG_DATABASE_PASSWORD }}@{{ localsettings.PG_DATABASE_HOST }}/{{ localsettings.UCR_DATABASE_NAME }}"
+UCR_DATABASE_URL = "postgresql://{{ localsettings.PG_DATABASE_USER }}:{{ localsettings.PG_DATABASE_PASSWORD }}@{{ localsettings.PG_DATABASE_HOST }}:{{localsettings.get('PG_DATABASE_PORT')}}/{{ localsettings.UCR_DATABASE_NAME }}"
 {% endif %}
 
 CTABLE_BACKENDS = {'SQL': 'ctable.backends.SqlBackend'}


### PR DESCRIPTION
implementing the idea of @proteusvacuum from http://manage.dimagi.com/default.asp?217882
UCR postgres requests were trying to connect on the wrong port. it was only a problem on staging but limited testing on prod indicates it shouldnt break anything
this is deployed to staging and i tested it in a private release on prod
cc: @emord 