### PR TITLE
Custom icds cert

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -13,8 +13,6 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http == True, action: site, site_name: cchq_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http_redirect == True, action: site, site_name: cchq_http_redirect }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.hq_status == True, action: site, site_name: hq_status }
-    - { role: nginx, when: proxy_type == 'nginx' and active_sites.icds_tableau == True, action: site, site_name: icds_tableau }
-    - { role: nginx, when: proxy_type == 'nginx' and active_sites.icds_tableau == True, action: site, site_name: icds_tableau_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.dhis == True, action: site, site_name: dhis }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.dhis == True, action: site, site_name: dhis_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech1 == True, action: site, site_name: motech1 }
@@ -25,10 +23,12 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.wiki == True, action: site, site_name: wiki_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech}
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech_http }
-    - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_ssl == True, action: site, site_name: commtrack_ssl }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.riakcs == True, action: site, site_name: riakcs }
     # Don't put any .commcarehq.org ssl configurations below commtrack, the ssl cert variable that gets loaded persists between roles
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_ssl == True, action: site, site_name: commtrack_ssl }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_http == True, action: site, site_name: commtrack_http }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.icds_tableau == True, action: site, site_name: icds_tableau }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.icds_tableau == True, action: site, site_name: icds_tableau_http }
     - { role: nginx, when: proxy_type == 'nginx', action: restart }
 
 - name: Newrelic Plugin Agent for Proxy

--- a/ansible/roles/nginx/tasks/install.yml
+++ b/ansible/roles/nginx/tasks/install.yml
@@ -91,3 +91,23 @@
     owner: root
     group: root
   when: not fake_ssl_cert and commtrack_key_file is defined
+
+- name: Copy icds SSL cert
+  sudo: yes
+  copy:
+    src: "{{ icds_nginx_combined_cert_file }}"
+    dest: "{{ ssl_certs_dir }}/{{ icds_nginx_ssl_cert }}"
+    mode: 0400
+    owner: root
+    group: root
+  when: not fake_ssl_cert and icds_nginx_combined_cert_file is defined
+
+- name: Copy icds  SSL Key
+  sudo: yes
+  copy:
+    src: "{{ icds_key_file }}"
+    dest: "{{ ssl_keys_dir }}/{{ icds_nginx_ssl_key }}"
+    mode: 0400
+    owner: root
+    group: root
+  when: not fake_ssl_cert and icds_key_file is defined

--- a/ansible/roles/nginx/vars/icds_tableau.yml
+++ b/ansible/roles/nginx/vars/icds_tableau.yml
@@ -1,4 +1,7 @@
 ---
+nginx_ssl_cert: "{{ icds_nginx_ssl_cert }}"
+nginx_ssl_key:  "{{ icds_nginx_ssl_key}}"
+
 nginx_sites:
 - server:
    file_name: icds_tableau

--- a/ansible/roles/nginx/vars/icds_tableau.yml
+++ b/ansible/roles/nginx/vars/icds_tableau.yml
@@ -1,6 +1,6 @@
 ---
 nginx_ssl_cert: "{{ icds_nginx_ssl_cert }}"
-nginx_ssl_key:  "{{ icds_nginx_ssl_key}}"
+nginx_ssl_key:  "{{ icds_nginx_ssl_key }}"
 
 nginx_sites:
 - server:

--- a/ansible/roles/nginx/vars/main.yml
+++ b/ansible/roles/nginx/vars/main.yml
@@ -13,6 +13,8 @@ nginx_ssl_cert: "{{ deploy_env }}_nginx_combined.crt"
 nginx_ssl_key: "{{ deploy_env }}_nginx_commcarehq.org.key"
 commtrack_nginx_ssl_cert: "{{ deploy_env }}_nginx_commtrack_combined.crt"
 commtrack_nginx_ssl_key: "{{ deploy_env }}_nginx_commtrack.org.key"
+icds_nginx_ssl_cert: "{{ deploy_env }}_nginx_icds_combined.crt"
+icds_nginx_ssl_key: "{{ deploy_env }}_nginx_icds.org.key"
 # providing this will ensure that the poodle vulnerability is closed
 nginx_ssl_protocols: "TLSv1 TLSv1.1 TLSv1.2"
 # RC4 is needed for J2ME so we have to have it enabled here.


### PR DESCRIPTION
Because the ICDS tableau server is hosted on the India cloud we need a new certificate for an endpoint that isn't india.commcarehq.org.  There is a bit of copy pasting in the copying certs to proxy step that could be refactored in the future.

@nickpell 