### PR TITLE
Fix broken nginx config

### DIFF
--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -2,7 +2,7 @@
 nginx_sites:
 - server:
    file_name: "{{ deploy_env }}_commcare"
-   listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env else '' }}"
+   listen: "443 ssl"
    server_name: "{{ SITE_HOST }}"
    client_max_body_size: 100m
    balancer: webworkers

--- a/ansible/roles/nginx/vars/main.yml
+++ b/ansible/roles/nginx/vars/main.yml
@@ -29,7 +29,6 @@ nginx_http_params:
   types_hash_max_size: 2048
 
 nginx_separate_logs_per_site: True
-primary_ssl_env: ""
 commcarehq_errors_repository: "https://github.com/dimagi/commcare-hq-errorpages.git"
 errors_home: "{{ www_home }}/error_root"
 error_pages:


### PR DESCRIPTION
Basically reverts dimagi/commcarehq-ansible#270

Not sure what changed, but recently when deploying the proxy it wants to do this:
```nginx
TASK: [nginx | Create the site configurations] ********************************
--- before: /etc/nginx/sites-available/production_commcare
+++ after: /home/salt/ansible/commcarehq-ansible/ansible/roles/nginx/templates/site.j2
@@ -16,21 +16,21 @@

   ssl_certificate /etc/pki/tls/certs/production_nginx_combined.crt;
   ssl_certificate_key /etc/pki/tls/private/production_nginx_commcarehq.org.key;
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers ...removed for brevity...;

       server_name www.commcarehq.org;
                     add_header X-Frame-Options SAMEORIGIN;
       client_max_body_size 100m;
       access_log /home/cchq/www/production/log/production-timing.log timing;
-      listen 443 ssl;
+      listen 443 ssl default_server;

     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $remote_addr;
```
which causes nginx to not start. I had this happen on staging, and subsequently edited the config file to get nginx to start. @benrudolph had it happen on prod; he also reverted manually.

I did some checking, and the `default_server` is not anywhere in the prod nginx configs (on the proxy: `grep -rni default_server /etc/nginx/` returns nothing).

@czue @TylerSheffels