### PR TITLE
Add libfreetype6-dev to common package installs

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -55,6 +55,7 @@
     - python-software-properties
     - mosh
     - libjpeg-dev
+    - libfreetype6-dev
     - gradle
     - ranger  # cmdline file browser
 


### PR DESCRIPTION
This is so django-simple-captcha can write text in images

@benrudolph cc @kaapstorm 