### PR TITLE
Accept a variable redis version

### DIFF
--- a/ansible/roles/redis/vars/main.yml
+++ b/ansible/roles/redis/vars/main.yml
@@ -8,4 +8,4 @@ env:
 
 redis_ubuntu_pkg:
   - python-selinux
-  - redis-server=3:3.0.5-1chl1~{{ ansible_lsb.codename}}1
+  - redis-server=3:3.*


### PR DESCRIPTION
Version `3:3.0.5-1chl1~trusty1` is no longer available, now it's `3:3.0.7-1chl1~trusty1`
@NoahCarnahan @dannyroberts 