### PR TITLE
start rejecting csrf failures

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -70,7 +70,7 @@ DATADOG_LOG_FILE = os.path.join('{{ log_home }}',"{{ localsettings.DEPLOY_MACHIN
 FORMPLAYER_TIMING_FILE = os.path.join('{{ log_home }}',"{{ localsettings.DEPLOY_MACHINE_NAME }}-formplayer.timing.log")
 FORMPLAYER_DIFF_FILE = os.path.join('{{ log_home }}',"{{ localsettings.DEPLOY_MACHINE_NAME }}-formplayer.diff.log")
 
-CSRF_SOFT_MODE = {{ localsettings.CSRF_SOFT_MODE | default(True) }}
+CSRF_SOFT_MODE = {{ localsettings.CSRF_SOFT_MODE | default(False) }}
 
 # Email setup
 # email settings: these ones are the custom hq ones


### PR DESCRIPTION
In spite of enabling CSRF on India, no one filed a bug indicating an unexpected behaviour (there were around 130 request rejections). I have analyzed logs from last 3 months [here](https://docs.google.com/spreadsheets/d/1jq1MwUiMmMr0klz5_kh-H54HVbcG2_M1vnPUHlxLBdU/edit) (from india+prod). There are couple of doubtful csrf rejections, these are not reproducible and they even look like expected behaviours. At this point, we should turn on CSRF rejection on Prod for a day/week, let users report a bug if any rejection is unexpected and fix them

Before merging this in, it would be good for anyone to review the [logs analysis](https://docs.google.com/spreadsheets/d/1jq1MwUiMmMr0klz5_kh-H54HVbcG2_M1vnPUHlxLBdU/edit) Best way to review and discuss might be either through doc comments or a quick voice chat.
@czue 
cc @benrudolph 