### PR TITLE
Add libffi task

### DIFF
--- a/ansible/roles/captain/tasks/main.yml
+++ b/ansible/roles/captain/tasks/main.yml
@@ -42,6 +42,12 @@
   tags:
     - slow
 
+- name: install apt requirements
+  apt: name={{ item }} state=present
+  sudo: yes
+  with_items:
+    - libffi-dev
+
 - name: Upgrade setuptools
   easy_install:
     # HACK: -U allows us to force update. In ansible 2.0 we can just use the state property


### PR DESCRIPTION
install apt requirements for captain (required for the github3py pip package). @millerdev