### PR TITLE
Move libffi to common installs

### DIFF
--- a/ansible/roles/captain/tasks/main.yml
+++ b/ansible/roles/captain/tasks/main.yml
@@ -42,12 +42,6 @@
   tags:
     - slow
 
-- name: install apt requirements
-  apt: name={{ item }} state=present
-  sudo: yes
-  with_items:
-    - libffi-dev
-
 - name: Upgrade setuptools
   easy_install:
     # HACK: -U allows us to force update. In ansible 2.0 we can just use the state property

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -58,6 +58,7 @@
     - libfreetype6-dev
     - gradle
     - ranger  # cmdline file browser
+    - libffi-dev  # Required for installing github3py
 
 - name: Set NPM registry
   command: 'npm config set registry http://registry.npmjs.org/'


### PR DESCRIPTION
@millerdev this is required now that github3py will be used in our prod environments