### PR TITLE
pip to upgrade supervisor

### DIFF
--- a/ansible/roles/supervisor/tasks/main.yml
+++ b/ansible/roles/supervisor/tasks/main.yml
@@ -11,18 +11,9 @@
   changed_when: false
   failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
 
-- name: Add git apt repo
-  apt_repository: repo='ppa:schooltool-owners/trunk' state=present
-  register: add_supervisor_ppa
-
-- name: Update package list
-  apt: update_cache=yes
-  when: add_supervisor_ppa|changed
-
-- name: install supervisor
-  apt: name=supervisor state=present
+- name: install supervisord
+  shell: 'pip install supervisor==3.2.3 --install-scripts /usr/local/bin'
   sudo: yes
-  when: not which_supervisord.stdout
 
 - name: check for sysvinit conf
   stat: path=/etc/init.d/supervisor

--- a/ansible/roles/supervisor/tasks/main.yml
+++ b/ansible/roles/supervisor/tasks/main.yml
@@ -11,6 +11,14 @@
   changed_when: false
   failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
 
+- name: Add git apt repo
+  apt_repository: repo='ppa:schooltool-owners/trunk' state=present
+  register: add_supervisor_ppa
+
+- name: Update package list
+  apt: update_cache=yes
+  when: add_supervisor_ppa|changed
+
 - name: install supervisor
   apt: name=supervisor state=present
   sudo: yes

--- a/ansible/roles/supervisor/tasks/main.yml
+++ b/ansible/roles/supervisor/tasks/main.yml
@@ -12,8 +12,10 @@
   failed_when: which_supervisord.rc != 0 and which_supervisord.rc != 1
 
 - name: install supervisord
-  shell: 'pip install supervisor==3.2.3 --install-scripts /usr/local/bin'
   sudo: yes
+  pip:
+    name: supervisor
+    version: 3.2.3
 
 - name: check for sysvinit conf
   stat: path=/etc/init.d/supervisor

--- a/ansible/roles/supervisor/tasks/main.yml
+++ b/ansible/roles/supervisor/tasks/main.yml
@@ -17,6 +17,12 @@
     name: supervisor
     version: 3.2.3
 
+- name: remove apt supervisor
+  sudo: yes
+  apt:
+    name: supervisor
+    state: absent
+
 - name: check for sysvinit conf
   stat: path=/etc/init.d/supervisor
   register: init_d_conf

--- a/ansible/roles/supervisor/templates/supervisord.upstart.conf.j2
+++ b/ansible/roles/supervisor/templates/supervisord.upstart.conf.j2
@@ -5,4 +5,4 @@ stop on runlevel [!2345]
 
 respawn
 
-exec {{ which_supervisord.stdout }} --nodaemon --configuration /etc/supervisord.conf
+exec /usr/local/bin/supervisord --nodaemon --configuration /etc/supervisord.conf


### PR DESCRIPTION
@millerdev @snopoke going to try and upgrade supervisord and see if it helps with deploy errors revolving around weirdness in supervisor. our version is 3 years old (3.0b2). seems like they've made a fair number of bug fixes since: http://supervisord.org/changes.html. will go through breaking changes and do staging upgrade first
