### PR TITLE
add nginx 500 page

### DIFF
--- a/ansible/roles/nginx/vars/main.yml
+++ b/ansible/roles/nginx/vars/main.yml
@@ -35,3 +35,5 @@ errors_home: "{{ www_home }}/error_root"
 error_pages:
   - "502 503 /errors/50x.html"
   - "400 /errors/400.html"
+  # if Django is not able to handle 500, then it's an outage?
+  - "500 /errors/outage.html"


### PR DESCRIPTION
Requires https://github.com/dimagi/commcare-hq-errorpages/pull/7

This shows ngnix 500 page if Django is down @snopoke 