### PR TITLE
j2me http

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -23,6 +23,7 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.wiki == True, action: site, site_name: wiki_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech}
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech_http }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http_j2me == True, action: site, site_name: cchq_http_j2me }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.riakcs == True, action: site, site_name: riakcs }
     # Don't put any .commcarehq.org ssl configurations below commtrack, the ssl cert variable that gets loaded persists between roles
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_ssl == True, action: site, site_name: commtrack_ssl }

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -578,6 +578,8 @@ MIA_THE_DEPLOY_BOT_API = '{{ localsettings.MIA_THE_DEPLOY_BOT_API }}'
 # See corehq/apps/builds/README.md for more information.
 BASE_ADDRESS = '{{ SITE_HOST }}'
 
+J2ME_ADDRESS = '{{ localsettings.J2ME_ADDRESS }}'
+
 CLOUDCARE_BASE_URL = '{{ localsettings.get('CLOUDCARE_BASE_URL', '') }}'
 
 EMAIL_USE_TLS = {{ localsettings.EMAIL_USE_TLS }}

--- a/ansible/roles/nginx/vars/cchq_http_j2me.yml
+++ b/ansible/roles/nginx/vars/cchq_http_j2me.yml
@@ -1,0 +1,33 @@
+---
+nginx_sites:
+- server:
+    file_name: "{{ deploy_env }}_commcare_j2me"
+    listen: "80"
+    server_name: "{{ J2ME_SITE_HOST }}"
+    client_max_body_size: 100m
+    balancer: webworkers
+    proxy_set_headers:
+    - "Host $http_host"
+    - "X-Forwarded-For $remote_addr"
+    add_header: "X-Frame-Options SAMEORIGIN"
+    access_log: "{{ log_home }}/{{ deploy_env }}-j2me-timing.log timing"
+    location1:
+     name: "~* /a/[^/]+/phone/keys/"
+     balancer: webworkers
+     proxy_next_upstream_tries: 1
+     proxy_read_timeout: 900s
+    location2:
+     name: "~* /a/[^/]+/receiver/"
+     balancer: webworkers
+     proxy_next_upstream_tries: 1
+     proxy_read_timeout: 900s
+    location3:
+     name: "~* /a/[^/]+/phone/restore/"
+     balancer: webworkers
+     proxy_next_upstream_tries: 1
+     proxy_read_timeout: 900s
+    location4:
+     name: "~* /a/[^/]+/apps/download/[a-z0-9]+/(profile|suite).xml"
+     balancer: webworkers
+     proxy_next_upstream_tries: 1
+     proxy_read_timeout: 900s

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -188,6 +188,7 @@ localsettings:
   JAR_KEY_ALIAS: ''
   JAR_KEY_PASS: ''
   JAR_STORE_PASS: ''
+  J2ME_ADDRESS: ''
   KAFKA_URL: ''
   KISSMETRICS_KEY: ''
 #  MAILCHIMP_APIKEY:

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -16,6 +16,7 @@ active_sites:
   cchq_redirect: True
   cchq_http: True
   cchq_http_redirect: True
+  cchq_http_j2me: False
   commtrack_ssl: True
   commtrack_http: True
   riakcs: True

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -3,6 +3,7 @@
 SITE_HOST: '{{ groups.proxy.0 }}'
 COMMTRACK_SITE_HOST: '{{ groups.proxy.0 }}'
 NO_WWW_SITE_HOST: '{{ groups.proxy.0 }}'
+J2ME_SITE_HOST: 'j2me.{{ groups.proxy.0 }}'
 
 testing: True
 


### PR DESCRIPTION
This enables using J2ME by hitting http endpoints, and will be necessary once we drop support for SHA1.

For india, we will jump immediately to this solution while production will continue to use https until we have to switch.  Prod will be setup to redirect http to https (in a separate PR) once CommCare on J2ME supports redirects.

@emord @ctsims 