### PR TITLE
Configure ES for cross-network clustering

### DIFF
--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -32,6 +32,12 @@ discovery.zen.ping.unicast.hosts: [
 {% endfor %}
 ]
 
+{% if inventory_hostname|ipaddr %}
+network.host: "{{ inventory_hostname }}"
+{% else %}
+network.host: "{{ lookup('dig', inventory_hostname, wantlist=True)[0] }}"
+{% endif %}
+
 index.search.slowlog.threshold.query.warn: 10s
 index.search.slowlog.threshold.query.info: 5s
 index.search.slowlog.threshold.query.debug: 2s

--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -22,11 +22,15 @@ discovery.zen.fd.ping_interval: 10s
 discovery.zen.fd.ping_retries: 20
 
 discovery.zen.ping.multicast.enabled: false
-{% if elasticsearch_endpoint|ipaddr %}
-discovery.zen.ping.unicast.hosts: ["{{ elasticsearch_endpoint }}:{{ elasticsearch_tcp_port }}"]
-{% else %}
-discovery.zen.ping.unicast.hosts: ["{{ lookup('dig', elasticsearch_endpoint, wantlist=True)[0] }}:{{ elasticsearch_tcp_port }}"]
-{% endif %}
+discovery.zen.ping.unicast.hosts: [
+{% for endpoint in groups.elasticsearch %}
+  {% if endpoint|ipaddr %}
+    "{{ endpoint }}:{{ elasticsearch_tcp_port }}",
+  {% else %}
+    "{{ lookup('dig', endpoint, wantlist=True)[0] }}:{{ elasticsearch_tcp_port }}",
+  {% endif %}
+{% endfor %}
+]
 
 index.search.slowlog.threshold.query.warn: 10s
 index.search.slowlog.threshold.query.info: 5s


### PR DESCRIPTION
@nickpell @snopoke

First commit allows us to manually specificy machines to search for when performing cluster discovery.  This is necessary when the machines aren't on the same network.  See [these docs](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/modules-discovery-zen.html#unicast) for more info.
Second commit sets `network.host` as described [here](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/modules-network.html#modules-network)