### PR TITLE
Comment on why the hostvars[riak_control] dict may be empty

### DIFF
--- a/ansible/roles/riakcs/join_cluster.yml
+++ b/ansible/roles/riakcs/join_cluster.yml
@@ -15,6 +15,9 @@
 
 #- debug: var=riak_cluster_status
 
+# If this line fails, it might be because you're not also deploying to the
+# control node This means it doesn't get processed and this stuff is never set.
+# Try including the first entry in [riakcs] in your `--limit=` declaration.
 - set_fact: riak_control_node_name="{{ hostvars[riakcs_control]['riak_nodename'] }}"
 - set_fact: riak_control_node_pattern="{{ riak_control_node_name | replace('.', '\\.') }}"
 - set_fact: node_in_cluster="{{ riak_cluster_status.get('stdout', '') | search(riak_control_node_pattern) }}"


### PR DESCRIPTION
@millerdev @danielroberts
Danny just had this same issue coming up.  I think it's triggered by limiting the machines that you deploy - I think the variables aren't set on the control node if it's not processed in the ansible command