### PR TITLE
proxy redirect urls hit by j2me from http to https

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -24,6 +24,7 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech}
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http_j2me == True, action: site, site_name: cchq_http_j2me }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_ssl_j2me == True, action: site, site_name: cchq_ssl_j2me }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.riakcs == True, action: site, site_name: riakcs }
     # Don't put any .commcarehq.org ssl configurations below commtrack, the ssl cert variable that gets loaded persists between roles
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_ssl == True, action: site, site_name: commtrack_ssl }

--- a/ansible/roles/nginx/vars/cchq_ssl_j2me.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl_j2me.yml
@@ -1,0 +1,28 @@
+---
+nginx_sites:
+- server:
+    file_name: "{{ deploy_env }}_commcare_j2me"
+    listen: "80"
+    server_name: "{{ J2ME_SITE_HOST }}"
+    client_max_body_size: 100m
+    balancer: webworkers
+    proxy_set_headers:
+    - "Host $http_host"
+    - "X-Forwarded-For $remote_addr"
+    add_header: "X-Frame-Options SAMEORIGIN"
+    access_log: "{{ log_home }}/{{ deploy_env }}-j2me-timing.log timing"
+    location1:
+     name: "~* /a/[^/]+/phone/keys/"
+     return: "302 https://{{ SITE_HOST }}$request_uri"
+    location2:
+     name: "~* /a/[^/]+/receiver/"
+     return: "302 https://{{ SITE_HOST }}$request_uri"
+    location3:
+     name: "~* /a/[^/]+/phone/restore/"
+     return: "302 https://{{ SITE_HOST }}$request_uri"
+    location4:
+     name: "~* /a/[^/]+/apps/download/[a-z0-9]+/(profile|suite).xml"
+     return: "302 https://{{ SITE_HOST }}$request_uri"
+    location5:
+     name: "~* /a/[^/]+/apps/download/[a-z0-9]+/modules-[0-9]+/forms-[0-9]+.xml"
+     return: "302 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -17,6 +17,7 @@ active_sites:
   cchq_http: True
   cchq_http_redirect: True
   cchq_http_j2me: False
+  cchq_ssl_j2me: False
   commtrack_ssl: True
   commtrack_http: True
   riakcs: True


### PR DESCRIPTION
For the interim period before sha1 is switched to sha256.  Blocking on j2me support for 302 redirects.