### PR TITLE
CSRF in soft mode by default

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -70,7 +70,7 @@ DATADOG_LOG_FILE = os.path.join('{{ log_home }}',"{{ localsettings.DEPLOY_MACHIN
 FORMPLAYER_TIMING_FILE = os.path.join('{{ log_home }}',"{{ localsettings.DEPLOY_MACHINE_NAME }}-formplayer.timing.log")
 FORMPLAYER_DIFF_FILE = os.path.join('{{ log_home }}',"{{ localsettings.DEPLOY_MACHINE_NAME }}-formplayer.diff.log")
 
-CSRF_SOFT_MODE = {{ localsettings.CSRF_SOFT_MODE | default(False) }}
+CSRF_SOFT_MODE = {{ localsettings.CSRF_SOFT_MODE | default(True) }}
 
 # Email setup
 # email settings: these ones are the custom hq ones


### PR DESCRIPTION
If `CSRF_SOFT_MODE` is True, CSRF failures on login URLs are not rejected. I am setting this to `True` on all envs by default. I will set this to `False` just on softlayer to see if users are facing any real issues. If I hear no complaints from users after a week of trial, I will change the setting to `False` on all envs.

@proteusvacuum 