### PR TITLE
500MB limit for client_max_body_size

### DIFF
--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -4,7 +4,7 @@ nginx_sites:
    file_name: "{{ deploy_env }}_commcare"
    listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env else '' }}"
    server_name: "{{ SITE_HOST }}"
-   client_max_body_size: 100m
+   client_max_body_size: 500m
    balancer: webworkers
    proxy_set_headers:
    - "Host $http_host"


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?226167#1148928

This was failing because the zip is almost 400MB, so nginx barfs. Manually edited on softlayer, but should probably be run on all other environments. 
@benrudolph @nickpell interrupt buddies

cc @dannyroberts code buddy