### PR TITLE
Setup proxy for a single MOTECH endpoint

### DIFF
--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -4,16 +4,25 @@ nginx_sites:
    file_name: motech
    listen: "443 ssl"
    # Move these to a localsetting?
-   server_name: endos-motech.commcarehq.org
+   server_name: motech.commcarehq.org
    proxy_set_headers:
    - "Host $http_host"
    - "X-Forwarded-For $remote_addr"
    - "X-Forwarded-Proto $scheme"
    - "X-Forwarded-Host $host:443"
+   error_page: "502 503 /errors/50x.html"
    location1:
-    name: /
-    proxy_pass: http://motech.internal.commcarehq.org:8080/motech-platform-server/
-    proxy_redirect: "http://endos-motech.commcarehq.org/motech-platform-server/ https://endos-motech.commcarehq.org/"
-   location2:
     name: /errors
     alias: "{{ errors_home }}/pages"
+  location2:
+    name: /supply
+    proxy_pass: http://motech-main.internal.commcarehq.org:8888/motech
+  location3:
+    name: /supply-dhis
+    proxy_pass: http://motech-main.internal.commcarehq.org:8888/dhis
+  location4:
+    name: /supply-test
+    proxy_pass: http://motech2.internal.commcarehq.org:8080/motech
+  location5:
+    name: /supply-test-dhis
+    proxy_pass: http://motech2.internal.commcarehq.org:8080/dhis

--- a/ansible/roles/nginx/vars/motech_http.yml
+++ b/ansible/roles/nginx/vars/motech_http.yml
@@ -4,7 +4,7 @@ nginx_sites:
 - server:
    file_name: "motech_http"
    listen: "80"
-   server_name: "endos-motech.commcarehq.org"
+   server_name: "motech.commcarehq.org"
    proxy_set_header: "Host $http_host"
    location1:
     name: /


### PR DESCRIPTION
Moving to a model where motech servers are at motech.commcarehq.org/INSTANCENAME

This configuration sets this up for the servers required for the UN Supply project.  (It also removes the configuration for the unused endos-motech.commcarehq.org machine).  

@czue @calellowitz @emord 
Can one of you review, merge and deploy? 