### PR TITLE
Add message about restarting node

### DIFF
--- a/ansible/roles/elasticsearch/tasks/rolling_restart.yml
+++ b/ansible/roles/elasticsearch/tasks/rolling_restart.yml
@@ -18,6 +18,8 @@
   sudo: true
   service: name=elasticsearch state=started
 
+- debug: msg="Sometimes we try to start the node too soon. If hung start node manually"
+
 - name: wait for node to restart
   shell: curl -I -s -m 2 http://localhost:9200 | head -n 1
   register: result


### PR DESCRIPTION
@czue I think this is what happened with es2 earlier. Thoughts on adding a message to warn the restarter they might need to go and do things manually?

cc @proteusvacuum 