### PR TITLE
Revert "Update main.yml"

### DIFF
--- a/ansible/roles/ecryptfs/tasks/main.yml
+++ b/ansible/roles/ecryptfs/tasks/main.yml
@@ -91,12 +91,7 @@
   changed_when: false
 
 - name: add user, noauto to mount conf
-  lineinfile:
-   dest: '/etc/mtab'
-   regexp: "^(.*)rw(.*)$"
-   line: '\1user,noauto,rw\2'
-   backup: yes
-   backrefs: yes
+  shell: "echo {{ mount_conf.stdout }} | sed -e 's/rw/user,noauto,rw/'"
   when: "'noauto' not in mount_conf.stdout"
   register: updated_mount_conf
 


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#387

We don't actually care about what's in `mtab`. The point is to add it `/etc/fstab` so that it's there after reboot.

This change broke the next task which actually adds it to `/etc/fstab`