### PR TITLE
Update config file name

### DIFF
--- a/ansible/roles/touchforms/tasks/main.yml
+++ b/ansible/roles/touchforms/tasks/main.yml
@@ -60,7 +60,7 @@
   sudo: yes
   template:
     src: application.properties.j2
-    dest: "{{ code_home }}/submodules/formplayer/config/{{ deploy_env }}.properties"
+    dest: "{{ code_home }}/submodules/formplayer/config/application.properties"
     group: cchq
     owner: cchq
     mode: 0644


### PR DESCRIPTION
@benrudolph: @wpride was proposing to rename this file from <env>.properties to application.properties. Any reason it was named <env>.properties originally? Seems like it always is copied in a specific environment's code root anyway.