### PR TITLE
Set zone for ES nodes for allocation awareness

### DIFF
--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -7,6 +7,12 @@ cluster.name: "{{ elasticsearch_cluster_name }}"
 
 node.name: "{{ elasticsearch_node_name }}"
 
+{% if elasticsearch_node_zone %}
+# Used for shard allocation awareness
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html
+node.zone: "{{ elasticsearch_node_zone }}"
+{% endif %}
+
 # disable multiple nodes starting from the same installation location
 node.max_local_storage_nodes: 1
 


### PR DESCRIPTION
@dannyroberts @millerdev @nickpell
Setting up forced allocation awareness for the ES migration:
https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html

(with https://github.com/dimagi/commcare-hq/pull/12041, although they don't need to be merged together)