### PR TITLE
kafka monitoring

### DIFF
--- a/ansible/deploy_db.yml
+++ b/ansible/deploy_db.yml
@@ -58,6 +58,8 @@
 - name: Kafka
   hosts: kafka
   sudo: yes
+  environment:
+    JMX_PORT: 9999
   roles:
     - {role: kafka, tags: 'kafka'}
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -28,6 +28,7 @@ riak_port: 8087
 riak_data_dir: "{{ encrypted_root }}/riak"
 stanchion_port: 8085
 stanchion_data_dir: "{{ encrypted_root }}/stanchion"
+zookeeper_client_port: 2181
 
 # commcare-hq connects to an S3-compatible service, which is Riak CS
 s3_blob_db_enabled: "{{ 'true' if groups.get('riakcs') else '' }}"

--- a/ansible/group_vars/kafka.yml
+++ b/ansible/group_vars/kafka.yml
@@ -1,0 +1,3 @@
+datadog_integrations:
+  - kafka
+  - kafka_consumer

--- a/ansible/group_vars/kafka.yml
+++ b/ansible/group_vars/kafka.yml
@@ -1,3 +1,4 @@
 datadog_integrations:
   - kafka
   - kafka_consumer
+  - zk

--- a/ansible/group_vars/zookeeper.yml
+++ b/ansible/group_vars/zookeeper.yml
@@ -1,0 +1,2 @@
+datadog_integrations:
+  - zk

--- a/ansible/group_vars/zookeeper.yml
+++ b/ansible/group_vars/zookeeper.yml
@@ -1,2 +1,0 @@
-datadog_integrations:
-  - zk

--- a/ansible/roles/datadog/templates/kafka.yaml.j2
+++ b/ansible/roles/datadog/templates/kafka.yaml.j2
@@ -1,0 +1,383 @@
+#
+# {{ ansible_managed }}
+#
+instances:
+  - host: localhost
+    port: 9999 # This is the JMX port on which Kafka exposes its metrics (usually 9999)
+    tags:
+      kafka: broker_{{ kafka_broker_id }}
+    name: kafka_instance
+
+init_config:
+  is_jmx: true
+
+  # Metrics collected by this check. You should not have to modify this.
+  conf:
+    # v0.8.2.x Producers
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=ProducerRequestMetrics,name=ProducerRequestRateAndTimeMs,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.producer.request_rate
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=ProducerRequestMetrics,name=ProducerRequestRateAndTimeMs,clientId=.*'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.producer.request_latency_avg
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=ProducerTopicMetrics,name=BytesPerSec,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.producer.bytes_out
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=ProducerTopicMetrics,name=MessagesPerSec,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.producer.message_rate
+
+
+    # v0.9.0.x Producers
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=.*'
+        attribute:
+          response-rate:
+            metric_type: gauge
+            alias: kafka.producer.response_rate
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=.*'
+        attribute:
+          request-rate:
+            metric_type: gauge
+            alias: kafka.producer.request_rate
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=.*'
+        attribute:
+          request-latency-avg:
+            metric_type: gauge
+            alias: kafka.producer.request_latency_avg
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=.*'
+        attribute:
+          outgoing-byte-rate:
+            metric_type: gauge
+            alias: kafka.producer.bytes_out
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=.*'
+        attribute:
+          io-wait-time-ns-avg:
+            metric_type: gauge
+            alias: kafka.producer.io_wait
+
+
+    # v0.8.2.x Consumers
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=ConsumerFetcherManager,name=MaxLag,clientId=.*'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.consumer.max_lag
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=ConsumerFetcherManager,name=MinFetchRate,clientId=.*'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.consumer.fetch_rate
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=ConsumerTopicMetrics,name=BytesPerSec,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.consumer.bytes_in
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=ConsumerTopicMetrics,name=MessagesPerSec,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.consumer.messages_in
+
+    # Offsets committed to ZooKeeper
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=ZookeeperConsumerConnector,name=ZooKeeperCommitsPerSec,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.consumer.zookeeper_commits
+    # Offsets committed to Kafka
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=ZookeeperConsumerConnector,name=KafkaCommitsPerSec,clientId=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.consumer.kafka_commits
+
+    # v0.9.0.x Consumers
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=consumer-fetch-manager-metrics,client-id=.*'
+        attribute:
+          bytes-consumed-rate:
+            metric_type: gauge
+            alias: kafka.consumer.bytes_in
+    - include:
+        domain: 'kafka.consumer'
+        bean_regex: 'kafka\.consumer:type=consumer-fetch-manager-metrics,client-id=.*'
+        attribute:
+          records-consumed-rate:
+            metric_type: gauge
+            alias: kafka.consumer.messages_in
+
+    #
+    # Aggregate cluster stats
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.net.bytes_out.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.net.bytes_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.messages_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.net.bytes_rejected.rate
+
+    #
+    # Request timings
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.fetch.failed.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.produce.failed.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.produce.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.produce.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.produce.time.99percentile
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.fetch_consumer.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.fetch_follower.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchConsumer'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.fetch_consumer.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.fetch_consumer.time.99percentile
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchFollower'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.fetch_follower.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.fetch_follower.time.99percentile
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=UpdateMetadata'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.update_metadata.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.update_metadata.time.99percentile
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Metadata'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.metadata.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.metadata.time.99percentile
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Offsets'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.offsets.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.offsets.time.99percentile
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.handler.avg.idle.pct.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.producer_request_purgatory.size
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=FetchRequestPurgatory,name=PurgatorySize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.fetch_request_purgatory.size
+
+    #
+    # Replication stats
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.under_replicated_partitions
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=IsrShrinksPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.replication.isr_shrinks.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=IsrExpandsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.replication.isr_expands.rate
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.replication.leader_elections.rate
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.replication.unclean_leader_elections.rate
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=KafkaController,name=OfflinePartitionsCount'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.offline_partitions_count
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=KafkaController,name=ActiveControllerCount'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.active_controller_count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=PartitionCount'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.partition_count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=LeaderCount'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.leader_count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.max_lag
+
+    #
+    # Log flush stats
+    #
+    - include:
+        domain: 'kafka.log'
+        bean: 'kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.log.flush_rate.rate

--- a/ansible/roles/datadog/templates/kafka_consumer.yaml.j2
+++ b/ansible/roles/datadog/templates/kafka_consumer.yaml.j2
@@ -1,0 +1,35 @@
+init_config:
+#  Customize the ZooKeeper connection timeout here
+  zk_timeout: 5
+#  Customize the Kafka connection timeout here
+  kafka_timeout: 5
+
+instances:
+  - kafka_connect_str: localhost:9092  # Should always be deployed to broker so localhost is OK
+    zk_connect_str: "{{ groups['zookeeper'][0] }}:{{ zookeeper_client_port }}"
+    zk_prefix: /0.8
+    consumer_groups:
+      'form-processsor':
+        'form-sql': [0] # For now we only have one partition, which is 0
+        form: [0]
+      'domains-to-es':
+        domain: [0]
+      'groups-to-es':
+        group: [0]
+      'groups-to-users':
+        group: [0]
+      'cases-to-es':
+        case: [0]
+        'case-sql': [0]
+      'ledgers-to-es':
+        ledger: [0]
+      'unknown-users':
+        'form': [0]
+        'form-sql': [0]
+      'users-to-es':
+        'commcare-user': [0]
+        'web-user': [0]
+      'sql-forms-to-es':
+        'form-sql': [0]
+      'sql-sms-to-es':
+        sms: [0]

--- a/ansible/roles/datadog/templates/riakcs.yaml.j2
+++ b/ansible/roles/datadog/templates/riakcs.yaml.j2
@@ -5,5 +5,5 @@ instances:
   - host: {{ inventory_hostname if inventory_hostname|ipaddr else lookup('dig', inventory_hostname, wantlist=True)[0] }}
     port: {{ riakcs_port }}
     is_secure: False
-    access_id: access-key
-    access_secret: access-secret
+    access_id: {{ s3_blob_db_access_key }}
+    access_secret: {{ s3_blob_db_secret_key }}

--- a/ansible/roles/datadog/templates/zk.yaml.j2
+++ b/ansible/roles/datadog/templates/zk.yaml.j2
@@ -1,0 +1,8 @@
+#
+# {{ ansible_managed }}
+#
+init_config:
+
+instances:
+  - host: localhost
+    port: 2181

--- a/ansible/roles/kafka/tasks/main.yml
+++ b/ansible/roles/kafka/tasks/main.yml
@@ -6,6 +6,12 @@
 - name: add user "kafka"
   user: name={{ kafka_group }} group={{ kafka_group }} shell=/sbin/nologin system=yes state=present
 
+- name: Set JMX_PORT in /etc/environment
+  lineinfile:
+    dest: /etc/environment
+    line: 'JMX_PORT=9999'
+    state: present
+
 - name: Download Kafka
   get_url: url="http://{{ apache_mirror }}/kafka/{{ kafka_version }}/kafka_2.10-{{ kafka_version }}.tgz" dest=/opt/kafka_2.10-{{ kafka_version }}.tgz
 

--- a/ansible/roles/zookeeper/defaults/main.yml
+++ b/ansible/roles/zookeeper/defaults/main.yml
@@ -1,2 +1,0 @@
----
-zookeeper_client_port: 2181


### PR DESCRIPTION
@snopoke initial setup with kafka monitoring. running into a couple issues that i'm still working out:

1. i can't seem to figure out or connect to the JMX port on prod or staging (can do so locally). without it, datadog can't pick up kafka stats
2. i'm confused as to how to figure out what the consumer groups are for each topic. i had thought that they would be the group-id for the consumer, but datadog doesn't seem to be picking any changes up. maybe @czue knows something