### PR TITLE
fix syntax for supervisor install check

### DIFF
--- a/ansible/roles/supervisor/tasks/main.yml
+++ b/ansible/roles/supervisor/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: install supervisor
   apt: name=supervisor state=present
   sudo: yes
-  when: not which_supervisord.stdout
+  when: which_supervisord.stdout == ""
 
 - name: check for sysvinit conf
   stat: path=/etc/init.d/supervisor


### PR DESCRIPTION
I happened to come upon this, but didn't end up running it again with this fix. This seems to be the preferred way to check for empty stdout, looking at the docs, and the current way was failing (though I can't say whether it's for this reason).