### PR TITLE
run "find supervisorctl path" in check mode

### DIFF
--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -26,6 +26,9 @@
   shell: 'dirname "$(which supervisorctl)"'
   register: dirname_which_supervisorctl
   changed_when: false
+  # run in check mode
+  always_run: yes
+
 
 - name: Copy sudoers file
   sudo: yes


### PR DESCRIPTION
Now `deploy_common.yml` can run start to finish in check mode without failing! (That exclamation point is pretty depressing...)