### PR TITLE
Revert "Let the ansible user sudo without a password"

### DIFF
--- a/ansible/roles/ansible-control/templates/sudoers.j2
+++ b/ansible/roles/ansible-control/templates/sudoers.j2
@@ -7,5 +7,5 @@ User_Alias ANSIBLE_USERS = {% for user in dev_users.present -%}
 {%- if not loop.last %}, {% endif %}
 {%- endfor %}
 
-{{ ansible_control_user }}    ALL=(ALL) NOPASSWD: ALL
+{{ ansible_control_user }}    ALL=(ALL) ALL
 ANSIBLE_USERS ALL = ({{ ansible_control_user }}) NOPASSWD: ALL


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#458
This actually isn't necessary, and it's overwridden by the cchq sudoers file anyways.  I think you just need to do something manual during initial set-up.