### PR TITLE
Add a read-only elasticsearch endpoint

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -25,6 +25,7 @@
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.motech == True, action: site, site_name: motech_http }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.cchq_http_j2me == True, action: site, site_name: cchq_http_j2me }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.riakcs == True, action: site, site_name: riakcs }
+    - { role: nginx, when: proxy_type == 'nginx' and active_sites.read_only_es == True, action: site, site_name: read_only_es}
     # Don't put any .commcarehq.org ssl configurations below commtrack, the ssl cert variable that gets loaded persists between roles
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_ssl == True, action: site, site_name: commtrack_ssl }
     - { role: nginx, when: proxy_type == 'nginx' and active_sites.commtrack_http == True, action: site, site_name: commtrack_http }

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -53,7 +53,10 @@ server {
     {% if v.get('is_internal', False) == True %}
         internal;
     {% endif %}
-    {% for x,y in v.iteritems() if x not in ['name', 'balancer', 'is_internal', 'proxy_set_headers'] %}
+    {% if v.get('if', False) %}
+        if {{ v['if'] }}
+    {% endif %}
+    {% for x,y in v.iteritems() if x not in ['name', 'balancer', 'is_internal', 'proxy_set_headers', 'if'] %}
         {{ x }} {{ y }};
     {% endfor %}
     {% for k,v in v.iteritems() if k == 'proxy_set_headers' %}

--- a/ansible/roles/nginx/vars/read_only_es.yml
+++ b/ansible/roles/nginx/vars/read_only_es.yml
@@ -1,0 +1,18 @@
+---
+# Provides a GET only access point for ES
+nginx_sites:
+- server:
+   file_name: "{{ deploy_env }}_read_only_es"
+   listen: "9201"
+   server_name: "{{ NO_WWW_SITE_HOST }}"
+   client_max_body_size: 100m
+   proxy_set_header: "Host $http_host"
+   location1:
+    name: /
+    if: '($request_method !~ "GET") {return 403; break;}'
+    proxy_pass: "http://{{ groups.elasticsearch.0 }}:{{ localsettings.ELASTICSEARCH_PORT }}"
+    proxy_redirect: "off"
+    proxy_set_headers:
+      - "X-Real-IP  $remote_addr"
+      - "X-Forwarded-For $proxy_add_x_forwarded_for"
+      - "Host $http_host"

--- a/ansible/vars/dev.yml
+++ b/ansible/vars/dev.yml
@@ -20,6 +20,7 @@ active_sites:
   commtrack_ssl: True
   commtrack_http: True
   riakcs: True
+  read_only_es: True
   hq_status: False
   icds_tableau: False
   dhis: False


### PR DESCRIPTION
This adds an endpoint for accessing elasticsearch that only accepts GET requests, and is therefore read only. It can be accessed on port 9201. 