### PR TITLE
putting shared drive on data disk

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -9,7 +9,7 @@ encrypted_root: "/opt/data"
 
 shared_drive_enabled: true  # overridden in ../config/$ENV/$ENV.yml
 shared_dir_gid: 1500  # This GID cannot already be allocated
-shared_dir_name: "shared_data{{ '_' ~ deploy_env if deploy_env != 'production' else '' }}"
+shared_dir_name: "shared{{ '_' ~ deploy_env if deploy_env != 'production' else '' }}"
 shared_data_dir: "/opt/{{ shared_dir_name }}"
 shared_mount_dir: "/mnt/{{ shared_dir_name }}"
 is_monolith: '{{ groups["all"]|length == 1 }}'

--- a/ansible/roles/shared_dir/tasks/setup_host.yml
+++ b/ansible/roles/shared_dir/tasks/setup_host.yml
@@ -12,6 +12,20 @@
     - nfs
     - shared_files
 
+- name: Format system data disk
+  sudo: yes
+  filesystem: fstype=ext4 dev={{ datadisk_device }}1
+  when: datadisk_device is defined
+  tags:
+    - shared_files
+
+- name: Mount system data disk
+  sudo: yes
+  mount: name={{ shared_data_dir }} src={{ datadisk_device }}1 fstype=ext4 state=mounted opts=defaults,noatime,nofail
+  when: datadisk_device is defined
+  tags:
+    - shared_files
+
 - name: Create shared directories
   sudo: yes
   file:


### PR DESCRIPTION
@snopoke @czue @millerdev @benrudolph 
Our prod db machine comes with a 160GB data disk that no one seems to know existed and has remained unmounted since the migration to virginia. This PR allows us to mount that drive make it the nfs drive, to deal with repeated issues we have running out of disk space on db0 and the shared drive. Once we switch to the new drive, i can manually rsync the contents of the old one over.