### PR TITLE
Change deploy-control to output the commands used to deploy control

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,8 @@ ENV=production && ansible-playbook -u root -i ../../commcare-hq/fab/inventory/in
 
 ### Setting up ansible control machine
 
-```bash
-ansible-deploy-control  # see init.sh for the full command that this is an alias for
-```
+This must be done as the root user.  Run `ansible-deploy-control` to get the
+proper command.
 
 ### Use your ssh key to authenticate
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -39,8 +39,11 @@ alias aps='ap deploy_stack.yml'
 alias update-code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 alias update_code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 
+# It aint pretty, but it gets the job done
 function ansible-deploy-control() {
-  ANSIBLE_CONTROL_USER=`whoami` && sudo /home/$ANSIBLE_CONTROL_USER/.virtualenvs/ansible/bin/ansible-playbook -u root -i inventories/localhost deploy_control.yml -e "@vars/$ENV/${ENV}_vault.yml" -e "@vars/$ENV/${ENV}_public.yml" --diff
+    echo "You must be root to deploy the control machine"
+    echo "Run \`su\` to become the root user, then paste in this command to deploy:"
+    echo 'USER='`whoami` '&& ANSIBLE_DIR=/home/$USER/commcarehq-ansible/ansible && /home/$USER/.virtualenvs/ansible/bin/ansible-playbook -u root -i $ANSIBLE_DIR/inventories/localhost $ANSIBLE_DIR/deploy_control.yml -e @$ANSIBLE_DIR/vars/production/production_vault.yml -e @$ANSIBLE_DIR/vars/production/production_public.yml --diff --ask-vault-pass'
 }
 
 function ansible-control-banner() {


### PR DESCRIPTION
@snopoke @benrudolph @millerdev 
We could probably tune the user permissions a bit better so we can deploy control from our normal users, but this approach isn't too bad for an infrequent workflow.