### PR TITLE
fixing cas cert ref

### DIFF
--- a/ansible/vars/softlayer/softlayer_public.yml
+++ b/ansible/vars/softlayer/softlayer_public.yml
@@ -81,7 +81,7 @@ nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/india.commcarehq.org.c
 icds_nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/icds.commcarehq.org.combined.crt'
 icds_key_file: '../config/{{ deploy_env }}/ssl/icds.commcarehq.org.key'
 
-cas_nginx_combined_cert_file: 'vars/{{ deploy_env}}/ssl/cas.commcarehq.org.combined.crt'
+cas_nginx_combined_cert_file: '../config/{{ deploy_env}}/ssl/cas.commcarehq.org.combined.crt'
 cas_key_file: '../config/{{ deploy_env }}/ssl/cas.commcarehq.org.key'
 
 supervisor_http_enabled: True


### PR DESCRIPTION
@snopoke 
I think this was just an oversight when certs were pulled out of ansible vault, but it was breaking `deploy_proxy`