### PR TITLE
Ce/pg dump

### DIFF
--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -45,17 +45,17 @@
     hour: 0
     weekday: "1,2,3,4,5,6"
     user: postgres
-    cron_file: ../crontab
+    cron_file: backup_postgres
   when: backup_postgres
 
 - name: Create Weekly Cron job
   sudo: yes
   cron:
     name: "Backup postgres weekly"
-    job: "/etc/cron.d/create_postgres_dump.sh weekly 28"
+    job: "/etc/cron.d/create_postgres_dump.sh weekly 21"
     minute: 0
     hour: 0
     weekday: 0
     user: postgres
-    cron_file: ../crontab
+    cron_file: backup_postgres
   when: backup_postgres

--- a/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
+++ b/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
@@ -3,7 +3,10 @@ BACKUP_TYPE=$1
 DAYS_TO_RETAIN_BACKUPS=$2
 
 TODAY=$(date +"%Y_%m_%d")
-pg_basebackup -D "{{ postgresql_backup_dir }}/postgres_${BACKUP_TYPE}_${TODAY}" -Ft -Xs -z
+DIRECTORY="{{ postgresql_backup_dir }}/postgres_${BACKUP_TYPE}_${TODAY}"
+pg_basebackup -D $DIRECTORY -Xs
+tar -cjf "${DIRECTORY}.tar.bz" $DIRECTORY
+rm -rf $DIRECTORY
 
 # Remove old backups of this backup type
-find {{ postgresql_backup_dir }} -mtime "+$DAYS_TO_RETAIN_BACKUPS" -name "postgres_${BACKUP_TYPE}_*" -exec rm -rf {} \;
+find {{ postgresql_backup_dir }} -mtime "+$DAYS_TO_RETAIN_BACKUPS" -name "postgres_${BACKUP_TYPE}_*" -exec rm {} \;

--- a/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
+++ b/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
@@ -5,7 +5,7 @@ DAYS_TO_RETAIN_BACKUPS=$2
 TODAY=$(date +"%Y_%m_%d")
 DIRECTORY="{{ postgresql_backup_dir }}/postgres_${BACKUP_TYPE}_${TODAY}"
 pg_basebackup -D $DIRECTORY -Xs
-tar -cjf "${DIRECTORY}.tar.bz" $DIRECTORY
+tar -cjf "${DIRECTORY}.tar.bz" -C "${DIRECTORY}" .
 rm -rf $DIRECTORY
 
 # Remove old backups of this backup type

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -191,12 +191,13 @@ vacuum_cost_delay = 20ms        # 0-100 milliseconds
                 # number of seconds; 0 disables
 
 {% if hot_standby_server|default(None) %}
-wal_level = hot_standby
 archive_mode = on
 archive_command = 'rsync -a %p postgres@{{ hot_standby_server }}:{{ archive_dir }}/%f'   # archive directory lives on first standby machine specified in the inventory file
 
-max_wal_senders = 3
 {% endif %}
+
+wal_level = hot_standby
+max_wal_senders = 3
 
 #------------------------------------------------------------------------------
 # REPLICATION


### PR DESCRIPTION
The old cron job wasnt being run, which i think had to with `/etc/crontab` not being reloaded but im not sure. This cron method works, and is the same as we use for the purging of the cache files on the shared drive. I also cut down how long we keep the weekly backups to free up some space.
@czue @snopoke