### PR TITLE
changing playbook to support the cas proxy removal from proxy group

### DIFF
--- a/ansible/deploy_common.yml
+++ b/ansible/deploy_common.yml
@@ -5,13 +5,13 @@
     - common
 
 - name: ufw (firewall)
-  hosts: '!proxy'
+  hosts: '!proxy:!cas_proxy'
   sudo: yes
   roles:
     - {role: ufw, tags: ufw, when: ufw_private_interface is defined}
 
 - name: ufw (proxy firewall)
-  hosts: 'proxy'
+  hosts: 'proxy:cas_proxy'
   sudo: yes
   tasks:
     - include: roles/ufw/tasks/proxy_ufw.yml tags=ufw-proxy


### PR DESCRIPTION
This pr should make the cas proxy no longer dependent on the proxy role. Then we can take it out of the proxy group, so we dont install the cchq site, and the bug where it has 2 default servers, prevent nginx from starting will be fixed.
@benrudolph cc: @snopoke 