### PR TITLE
Add group tags to datadog conf

### DIFF
--- a/ansible/roles/datadog/templates/datadog.conf.j2
+++ b/ansible/roles/datadog/templates/datadog.conf.j2
@@ -6,7 +6,9 @@
 [Main]
 dd_url: https://app.datadoghq.com
 api_key: {{ DATADOG_API_KEY }}
-tags: environment:{{ deploy_env }}
+tags: {% for group, group_hosts in groups.items() -%}
+    {%- if inventory_hostname in group_hosts %}group:{{ group }}, {% endif -%}
+{%- endfor %} environment:{{ deploy_env }}
 
 # use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
 gce_updated_hostname: yes


### PR DESCRIPTION
Make it easier to query groups of hosts (such as "group:riakcs") in datadog.

Tested locally with vagrant to make sure it works as expected. Not deployed yet. Will deploy once reviewed/merged.

@esoergel 