### PR TITLE
Route formplayer requests based on sessionid

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -5,7 +5,7 @@
 {% for balancer in item.server.get('balancers', []) %}
 upstream {{ balancer.name }} {
   {% if balancer.get('method') %}
-  {{ balancer.method }}
+  {{ balancer.method }};
   {% else %}
   least_conn;
   {% endif %}

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -4,7 +4,12 @@
 
 {% for balancer in item.server.get('balancers', []) %}
 upstream {{ balancer.name }} {
+  {% if balancer.get('method') %}
+  {{ balancer.method }}
+  {% else %}
   least_conn;
+  {% endif %}
+
 {% for host in groups[balancer.hosts] %}
   server {{ host }}:{{ balancer.port }};
 {% endfor %}

--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -8,6 +8,7 @@ nginx_sites:
     - name: "{{ deploy_env }}_formplayer"
       hosts: touchforms
       port: "{{ formplayer_port }}"
+      method: "hash $cookie_sessionid consistent"
    file_name: "{{ deploy_env }}_commcare"
    listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env else '' }}"
    server_name: "{{ SITE_HOST }}"


### PR DESCRIPTION
@wpride @dannyroberts ok so here's one option we talked about. Not positive it'll work, but this'll require formplayer to make all its requests like `/formplayer/my-domain/my-username` then it'll get proxied to the the `formplayer` upstream and be balanced with `hash $request_uri consistent` which will then hash based on domain and username. _hopefully_ this'll mean that data is divided equally among all servers that we have. and we can then avoid using the nfs and store directly on `/opt/data`, the encrypted drive