### PR TITLE
Add CDC MOTECH Server

### DIFF
--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -20,3 +20,6 @@ nginx_sites:
      - name: /supply-dhis
        proxy_pass: http://motech-main.internal.commcarehq.org:8888/supply-dhis
        proxy_read_timeout: 180s
+     - name: /cdc-moz
+       proxy_pass: http://motech3.internal.commcarehq.org:8080/cdc-moz
+       proxy_read_timeout: 180s


### PR DESCRIPTION
This previously failed because the DNS wasn't configured correctly for motech3.internal.commcarehq.org.   This has now been fixed.