### PR TITLE
Proxy to next server on 403 from Riak CS

### DIFF
--- a/ansible/roles/nginx/vars/riakcs.yml
+++ b/ansible/roles/nginx/vars/riakcs.yml
@@ -22,3 +22,6 @@ nginx_sites:
        proxy_read_timeout: 90
        proxy_buffer_size: 64k
        proxy_buffers: 8 64k
+       # http_403 from Riak CS is an indication that Riak is down
+       proxy_next_upstream: error timeout http_403
+       proxy_next_upstream_tries: 3


### PR DESCRIPTION
Hopefully this will fix Riak node down causing error on client.

I've repeatedly observed errors like this in Riak CS access log when it's corresponding Riak service is down:
```
/var/log/riak-cs/access.log.2016_08_25_22:172.24.32.20 - - [25/Aug/2016:22:46:51 +0000] "PUT /buckets/blobdb/objects/commcarehq%2Fd<snip-production-doc-name>.xml.adf0e9982920427fb8353942c3828b58 HTTP/1.0" 403 309 "" "Boto3/1.2.3 Python/2.7.6 Linux/3.13.0-86-generic Botocore/1.3.30 Resource"
```
The cluster is usually still operational when this occurs, it (usually) just has one node down. This change should make the proxy try the request on the next node, which is hopefully not down and can service the request without causing the client to error out.

OOM killer has been the cause of Riak going down, and is the root cause/motivation for this workaround.

I'll deploy it after sanity check from code reviewer.

@dannyroberts cc @NoahCarnahan 