### PR TITLE
Fix noisy ansible managed comment

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-ansible_managed = Ansible managed, do not edit directly: {file} by {uid} on {host}
+ansible_managed = Ansible managed, do not edit directly


### PR DESCRIPTION
Comment was different for each user doing deploys causing annoying comment-only file changes. I would have liked to include the relative file path inside the ansible repo in the comment, but I couldn't find a way to format the `{file}` variable :(

@calellowitz @NoahCarnahan 