### PR TITLE
pg s3

### DIFF
--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -45,7 +45,7 @@
     owner: postgres
     mode: 0700
     backup: yes
-  when: backup_postgres
+  when: postgres_s3
 
 - name: Create Daily Cron job
   sudo: yes

--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -36,6 +36,12 @@
     backup: yes
   when: backup_postgres
 
+- name: install tinys3
+  sudo: yes
+  pip:
+    name: tinys3
+    version: 0.1.11
+
 - name: Copy s3 upload script
   sudo: yes
   template:

--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -36,6 +36,17 @@
     backup: yes
   when: backup_postgres
 
+- name: Copy s3 upload script
+  sudo: yes
+  template:
+    src: "backup_snapshots.py.j2"
+    dest: "/etc/cron.d/backup_snapshots.py"
+    group: postgres
+    owner: postgres
+    mode: 0700
+    backup: yes
+  when: backup_postgres
+
 - name: Create Daily Cron job
   sudo: yes
   cron:

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -1,10 +1,11 @@
-#!/bin/python
+#!/usr/bin/python
 import sys
+import tinys3
 
 if len(sys.argv) != 2:
-    raise Exception('Usage is backup_snapshots <filename>')
+    raise Exception('Usage is backup_snapshots.py <filename>')
 
 filename = sys.argv[1]
 s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}', '{{ localsettings.AMAZON_S3_SECRET_KEY }}', tls=True)
 f = open(filename, 'r')
-s3_connection.upload(filename, f, '{{ deploy_env }}-postgres-backups')
+s3_connection.upload(filename, f, 'dimagi-{{ deploy_env }}-postgres-backups')

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -6,6 +6,9 @@ if len(sys.argv) != 2:
     raise Exception('Usage is backup_snapshots.py <filename>')
 
 filename = sys.argv[1]
-s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}', '{{ localsettings.AMAZON_S3_SECRET_KEY }}', tls=True)
+s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}',
+                                  '{{ localsettings.AMAZON_S3_SECRET_KEY }}',
+                                  tls=True,
+                                  headers={'x-amz-server-side​-encryption':'AES256')
 f = open(filename, 'r')
 s3_connection.upload(filename, f, 'dimagi-{{ deploy_env }}-postgres-backups')

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -9,6 +9,6 @@ filename = sys.argv[1]
 s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}',
                                   '{{ localsettings.AMAZON_S3_SECRET_KEY }}',
                                   tls=True,
-                                  headers={'x-amz-server-side​-encryption':'AES256')
+                                  headers={'x-amz-server-side​-encryption':'AES256'})
 f = open(filename, 'r')
 s3_connection.upload(filename, f, 'dimagi-{{ deploy_env }}-postgres-backups')

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -1,0 +1,10 @@
+#!/bin/python
+import sys
+
+if len(sys.argv) != 2:
+    raise Exception('Usage is backup_snapshots <filename>')
+
+filename = sys.argv[1]
+s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}', '{{ localsettings.AMAZON_S3_SECRET_KEY }}', tls=True)
+f = open(filename, 'r')
+s3_connection.upload(filename, f, '{{ deploy_env }}-postgres-backups')

--- a/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
+++ b/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
@@ -11,4 +11,6 @@ rm -rf $DIRECTORY
 # Remove old backups of this backup type
 find {{ postgresql_backup_dir }} -mtime "+$DAYS_TO_RETAIN_BACKUPS" -name "postgres_${BACKUP_TYPE}_*" -exec rm {} \;
 
+{% if postgres_s3 %}
 /etc/cron.d/backup_snapshots.py "${DIRECTORY}.tar.bz"
+{% endif %}

--- a/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
+++ b/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
@@ -10,3 +10,5 @@ rm -rf $DIRECTORY
 
 # Remove old backups of this backup type
 find {{ postgresql_backup_dir }} -mtime "+$DAYS_TO_RETAIN_BACKUPS" -name "postgres_${BACKUP_TYPE}_*" -exec rm {} \;
+
+/etc/cron.d/backup_snapshots.py "${DIRECTORY}.tar.bz"

--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -92,6 +92,7 @@ postgres_config:
 shared_drive_enabled: True
 backup_postgres: False
 backup_blobdb: True
+postgres_s3: False
 
 supervisor_http_enabled: True
 supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"

--- a/ansible/vars/production/production_public.yml
+++ b/ansible/vars/production/production_public.yml
@@ -69,6 +69,7 @@ keystore_file: '../config/DimagiKeyStore'
 backup_blobdb: False
 backup_postgres: True
 backup_es: True
+postgres_s3: True
 
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 

--- a/ansible/vars/softlayer/softlayer_public.yml
+++ b/ansible/vars/softlayer/softlayer_public.yml
@@ -62,6 +62,7 @@ keystore_file: '../config/DimagiKeyStore'
 backup_blobdb: False
 backup_postgres: True
 backup_es: True
+postgres_s3: False
 
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 

--- a/ansible/vars/staging/staging_public.yml
+++ b/ansible/vars/staging/staging_public.yml
@@ -59,6 +59,7 @@ keystore_file: '../config/DimagiKeyStore'
 backup_blobdb: False
 backup_postgres: False
 backup_es: False
+postgres_s3: False
 
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 

--- a/ansible/vars/swiss/swiss_public.yml
+++ b/ansible/vars/swiss/swiss_public.yml
@@ -49,6 +49,7 @@ keystore_file: '../config/DimagiKeyStore'
 backup_blobdb: False
 backup_postgres: False
 backup_es: False
+postgres_s3: False
 
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 


### PR DESCRIPTION
@snopoke @czue @benrudolph 
This sends our postgres backups to s3 so we are not tied to rackspace or in case something happens to our standby machine where they are stored locally. I have configured to the s3 bucket to delete them after 30 days but we can shorten that time period if necessary. This will replace our rackspace backups that used to be on prod, and have the same goal as the evault backups we do in India.