### PR TITLE
Ce/pg s3

### DIFF
--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -36,12 +36,24 @@
     backup: yes
   when: backup_postgres
 
-- name: install tinys3
+- name: install boto3
   sudo: yes
   pip:
-    name: tinys3
-    version: 0.1.11
+    name: boto3
+    version: 1.4.0
+  when: postgres_s3
 
+- name: copy boto3 credentials file
+  sudo: yes
+  template:
+    src: "aws_credentials.j2"
+    dest: "{{ postgresql_dir_original_path }}/.aws/credentials"
+    group: postgres
+    owner: postgres
+    mode: 0700
+    backup: yes
+  when: postgres_s3
+  
 - name: Copy s3 upload script
   sudo: yes
   template:

--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -43,6 +43,16 @@
     version: 1.4.0
   when: postgres_s3
 
+- name: Create aws config directory
+  sudo: yes
+  file:
+    path: '{{ postgresql_dir_original_path }}/.aws'
+    owner: postgres
+    group: postgres
+    mode: 0755
+    state: directory
+  when: postgres_s3
+    
 - name: copy boto3 credentials file
   sudo: yes
   template:

--- a/ansible/roles/pg_standby/templates/aws_credentials.j2
+++ b/ansible/roles/pg_standby/templates/aws_credentials.j2
@@ -1,0 +1,6 @@
+
+# {{ ansible_managed }}
+
+[default]
+aws_access_key_id={{ localsettings.AMAZON_S3_SECRET_KEY }}
+aws_secret_access_key={{ localsettings.AMAZON_S3_ACCESS_KEY }}

--- a/ansible/roles/pg_standby/templates/aws_credentials.j2
+++ b/ansible/roles/pg_standby/templates/aws_credentials.j2
@@ -2,5 +2,5 @@
 # {{ ansible_managed }}
 
 [default]
-aws_access_key_id={{ localsettings.AMAZON_S3_SECRET_KEY }}
-aws_secret_access_key={{ localsettings.AMAZON_S3_ACCESS_KEY }}
+aws_access_key_id={{ localsettings.AMAZON_S3_ACCESS_KEY }}
+aws_secret_access_key={{ localsettings.AMAZON_S3_SECRET_KEY }}

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -9,6 +9,6 @@ filename = sys.argv[1]
 s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}',
                                   '{{ localsettings.AMAZON_S3_SECRET_KEY }}',
                                   tls=True,
-                                  headers={'x-amz-server-side​-encryption':'AES256'})
+                                  headers={'x-amz-server-side-encryption':'AES256'})
 f = open(filename, 'r')
 s3_connection.upload(filename, f, 'dimagi-{{ deploy_env }}-postgres-backups')

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -8,7 +8,8 @@ if len(sys.argv) != 2:
 filename = sys.argv[1]
 s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}',
                                   '{{ localsettings.AMAZON_S3_SECRET_KEY }}',
-                                  tls=True,
-                                  headers={'x-amz-server-side-encryption':'AES256'})
+                                  tls=True)
 f = open(filename, 'r')
-s3_connection.upload(filename, f, 'dimagi-{{ deploy_env }}-postgres-backups')
+s3_connection.upload(filename, f,
+                     'dimagi-{{ deploy_env }}-postgres-backups',
+                     headers={'x-amz-server-side-encryption':'AES256'})

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -8,4 +8,4 @@ if len(sys.argv) != 2:
 filename = sys.argv[1]
 s3 = boto3.client('s3')
 s3.upload_file(filename, 'dimagi-{{ deploy_env }}-postgres-backups',
-               filename, extra_args={'ServerSideEncryption':'AES256'})
+               filename, ExtraArgs={'ServerSideEncryption':'AES256'})

--- a/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
+++ b/ansible/roles/pg_standby/templates/backup_snapshots.py.j2
@@ -1,15 +1,11 @@
 #!/usr/bin/python
 import sys
-import tinys3
+import boto3
 
 if len(sys.argv) != 2:
     raise Exception('Usage is backup_snapshots.py <filename>')
 
 filename = sys.argv[1]
-s3_connection = tinys3.Connection('{{ localsettings.AMAZON_S3_ACCESS_KEY }}',
-                                  '{{ localsettings.AMAZON_S3_SECRET_KEY }}',
-                                  tls=True)
-f = open(filename, 'r')
-s3_connection.upload(filename, f,
-                     'dimagi-{{ deploy_env }}-postgres-backups',
-                     headers={'x-amz-server-side-encryption':'AES256'})
+s3 = boto3.client('s3')
+s3.upload_file(filename, 'dimagi-{{ deploy_env }}-postgres-backups',
+               filename, extra_args={'ServerSideEncryption':'AES256'})


### PR DESCRIPTION
@gcapalbo @benrudolph 
Final fixes for postgres s3 uploads. These have run successfully on prod. S3 has a size limit for individual file uploads that we were hitting on prod but not in my testing on staging, but allows multipart uploads. Boto3 handles that automatically while tinys3 was just throwing errors so i switched libraries but otherwise maintained the same functionality.