### PR TITLE
moving snapshot cron job back to allow checkpoints to happen first

### DIFF
--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -132,7 +132,8 @@
   cron:
     name: "Daily ES Snapshot"
     job: "/etc/cron.d/create_es_snapshot.py"
-    special_time: daily
+    hour: 4
+    minute: 0
     user: root
     cron_file: create_es_snapshot
   when: backup_es and inventory_hostname == "{{ groups.elasticsearch.0 }}"

--- a/ansible/roles/elasticsearch/templates/create_es_snapshot.py.j2
+++ b/ansible/roles/elasticsearch/templates/create_es_snapshot.py.j2
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 
 def get_snapshot_client():
-    es = Elasticsearch('{{ groups.elasticsearch.0 }}', timeout=60)
+    es = Elasticsearch('{{ groups.elasticsearch.0 }}', timeout=3600)
     snapshot_client = SnapshotClient(es)
     return snapshot_client
 


### PR DESCRIPTION
moves the cron job to snapshot es restores from midnight to 4 so that the pillow checkpoint job from https://github.com/dimagi/commcare-hq/pull/13154 can finish running first