### PR TITLE
adding archive timeout

### DIFF
--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -193,6 +193,7 @@ vacuum_cost_delay = 20ms        # 0-100 milliseconds
 {% if hot_standby_server|default(None) %}
 archive_mode = on
 archive_command = 'rsync -a %p postgres@{{ hot_standby_server }}:{{ archive_dir }}/%f'   # archive directory lives on first standby machine specified in the inventory file
+archive_timeout = 60
 
 {% endif %}
 


### PR DESCRIPTION
@czue @snopoke @benrudolph 
It looks like the standby is lagging behind the master server (at least in the afternoon in boston) probably due to the low volume of writes. This forces the master to send an update to the standby ever 60 seconds even if the WAL is not filled which should cut down lag to a minute at most.