### PR TITLE
Purge old formplayer files

### DIFF
--- a/ansible/roles/formplayer/tasks/main.yml
+++ b/ansible/roles/formplayer/tasks/main.yml
@@ -5,6 +5,17 @@
     - sqlite3
     - libsqlite3-dev
 
+- name: Create purging cron jobs
+  sudo: yes
+  cron:
+    name: "{{ item.name }}"
+    special_time: daily
+    job: "find {{ item.dir }} -maxdepth {{ item.maxdepth }} -type {{ item.type }}  -mtime +{{ item.max_age }} -delete"
+    user: root
+    cron_file: purge_formplayer_files
+  with_items:
+    - {name: 'Purge temp files', dir: "/tmp", max_age: 2, type: f, maxdepth: 1}
+
 - name: Formplayer build dir
   file:
     path: "{{ item }}"


### PR DESCRIPTION
@czue @wpride every time formplayer downloads a jar it temporarily saves it in `/tmp` so we have a huge number of ccz files in `/tmp`. also large number of `tomcat.*` directories which from a little reading shouldn't be deleted while the server is running. this task will just delete the old files (including the cczs, but excluding the tomcat dirs) while i figure out a way to safely delete the `tomcat.` dirs 