### PR TITLE
move elastic datadog integration to ES machines

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -68,4 +68,17 @@ s3_blob_db_url: "http://{{ groups['proxy'][0] }}:{{ riakcs_port }}"
 s3_blob_db_access_key: "{{ riakcs_s3_access_key if riakcs_s3_access_key is defined else (hostvars[riakcs_control]['riak_key'] if s3_blob_db_enabled else '') }}"
 s3_blob_db_secret_key:  "{{ riakcs_s3_secret_key if riakcs_s3_secret_key is defined else (hostvars[riakcs_control]['riak_secret'] if s3_blob_db_enabled else '') }}"
 
-datadog_integrations: []
+datadog_integration_celery: false
+datadog_integration_cloudant: false
+datadog_integration_elastic: false
+datadog_integration_gunicorn: false
+datadog_integration_kafka: false
+datadog_integration_kafka_consumer: false
+datadog_integration_nginx: false
+datadog_integration_pgbouncer: false
+datadog_integration_postgres: false
+datadog_integration_rabbitmq: false
+datadog_integration_redisdb: false
+datadog_integration_riak: false
+datadog_integration_riakcs: false
+datadog_integration_zk: false

--- a/ansible/group_vars/elasticsearch.yml
+++ b/ansible/group_vars/elasticsearch.yml
@@ -1,2 +1,1 @@
-datadog_integrations:
-  - elastic
+datadog_integration_elastic: true

--- a/ansible/group_vars/elasticsearch.yml
+++ b/ansible/group_vars/elasticsearch.yml
@@ -1,0 +1,2 @@
+datadog_integrations:
+  - elastic

--- a/ansible/group_vars/kafka.yml
+++ b/ansible/group_vars/kafka.yml
@@ -1,4 +1,3 @@
-datadog_integrations:
-  - kafka
-  - kafka_consumer
-  - zk
+datadog_integration_kafka: true
+datadog_integration_kafka_consumer: true
+datadog_integration_zk: true

--- a/ansible/group_vars/postgresql.yml
+++ b/ansible/group_vars/postgresql.yml
@@ -1,4 +1,3 @@
-# elastic included here since we only need one agent per cluster
 # redis and rabbit included here since group vars get overriden if a host matches multiple groups
 datadog_integrations:
   - postgres

--- a/ansible/group_vars/postgresql.yml
+++ b/ansible/group_vars/postgresql.yml
@@ -1,8 +1,6 @@
 # redis and rabbit included here since group vars get overriden if a host matches multiple groups
-datadog_integrations:
-  - postgres
-  - pgbouncer
-  - elastic
-  - redisdb
-  - rabbitmq
-  - cloudant
+datadog_integration_cloudant: true
+datadog_integration_pgbouncer: true
+datadog_integration_postgres: true
+datadog_integration_rabbitmq: true
+datadog_integration_redisdb: true

--- a/ansible/group_vars/proxy.yml
+++ b/ansible/group_vars/proxy.yml
@@ -1,2 +1,1 @@
-datadog_integrations:
-  - nginx
+datadog_integration_nginx: true

--- a/ansible/group_vars/riakcs.yml
+++ b/ansible/group_vars/riakcs.yml
@@ -2,6 +2,5 @@
 # http://docs.basho.com/riak/latest/ops/tuning/linux/#Storage-and-File-System-Tuning
 datavol_opts: barrier=0,data=writeback
 
-datadog_integrations:
-  - riak
-  - riakcs
+datadog_integration_riak: true
+datadog_integration_riakcs: true

--- a/ansible/group_vars/webworkers.yml
+++ b/ansible/group_vars/webworkers.yml
@@ -1,3 +1,2 @@
 upstream_port: "{{ django_port }}"
-datadog_integrations:
-  - gunicorn
+datadog_integration_gunicorn: true

--- a/ansible/roles/datadog/tasks/integrations.yml
+++ b/ansible/roles/datadog/tasks/integrations.yml
@@ -5,7 +5,7 @@
     sha256sum: "{{ datadog_cloudant_sha256sum }}"
     force: yes
   notify: restart datadog
-  when: "'cloudant' in datadog_integrations"
+  when: datadog_integration_cloudant
 
 - name: Install celery check
   get_url:
@@ -18,9 +18,21 @@
   when: inventory_hostname == groups.celery[0]
 
 - name: add datadog integration configs
-  template: src={{ item }}.yaml.j2 dest=/etc/dd-agent/conf.d/{{ item }}.yaml
+  template: src={{ item.split('_', 2)[-1] }}.yaml.j2 dest=/etc/dd-agent/conf.d/{{ item.split('_', 2)[-1] }}.yaml
   notify: restart datadog
   tags:
     - datadog_integrations
-  with_items: "{{ datadog_integrations|default([]) }}"
-
+  when: item
+  with_items:
+    - datadog_integration_elastic
+    - datadog_integration_gunicorn
+    - datadog_integration_kafka
+    - datadog_integration_kafka_consumer
+    - datadog_integration_nginx
+    - datadog_integration_pgbouncer
+    - datadog_integration_postgres
+    - datadog_integration_rabbitmq
+    - datadog_integration_redisdb
+    - datadog_integration_riak
+    - datadog_integration_riakcs
+    - datadog_integration_zk

--- a/ansible/roles/datadog/templates/elastic.yaml.j2
+++ b/ansible/roles/datadog/templates/elastic.yaml.j2
@@ -4,6 +4,6 @@
 init_config:
 
 instances:
-  - url: http://localhost:9200
+  - url: http://{{ inventory_hostname }}:9200
     tags:
       - environment:{{ deploy_env }}

--- a/ansible/roles/datadog/templates/elastic.yaml.j2
+++ b/ansible/roles/datadog/templates/elastic.yaml.j2
@@ -4,6 +4,6 @@
 init_config:
 
 instances:
-  - url: http://{{ elasticsearch_endpoint }}:9200
+  - url: http://localhost:9200
     tags:
       - environment:{{ deploy_env }}


### PR DESCRIPTION
We're already running the agent on the ES machines. This just puts the ES integration on those machines instead of on the PG machine. This should make the builtin dashboards work better: https://app.datadoghq.com/screen/integration/elasticsearch