### PR TITLE
specifying endpoint in es snapshot setup

### DIFF
--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -113,7 +113,7 @@
   uri:
     url: 'http://{{ groups.elasticsearch.0 }}:9200/_snapshot/{{ es_repository_name }}'
     method: PUT
-    body: ' {"type": "s3", "settings": {"bucket": "{{ es_snapshot_bucket }}", "compress": "true", "server_side_encryption": "true" }}'
+    body: ' {"type": "s3", "settings": {"bucket": "{{ es_snapshot_bucket }}", "compress": "true", "server_side_encryption": "true", "endpoint": "s3.{{ aws_region }}.amazonaws.com" }}'
   when: backup_es and inventory_hostname == "{{ groups.elasticsearch.0 }}"
 
 - name: Copy es backup script


### PR DESCRIPTION
@snopoke @czue @benrudolph 
It turns out that the aws plugin for elasticsearch has a hardcoded list of supported regions which does not include the mumbai datacenter, so to get it to work in india i had to specify an endpoint instead of a region. (This is deployed and verified that the snapshots are succeeding)