### PR TITLE
cchq owns java

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -2,4 +2,4 @@ ansible==1.9.6
 netaddr
 dnspython
 passlib
-cryptography
+cryptography==1.4

--- a/ansible/roles/java/files/install_java.sh
+++ b/ansible/roles/java/files/install_java.sh
@@ -7,7 +7,7 @@ rm -rf /usr/lib/jvm/jdk1.7.0 || true
 rm -rf /usr/lib/jvm/jdk1.7.0_67 || true
 mv jdk1.7.0_67/ /usr/lib/jvm/
 ln -s /usr/lib/jvm/jdk1.7.0_67/ /usr/lib/jvm/jdk1.7.0
-chown cchq:cchq /usr/lib/jvm/*
+chown -R cchq:cchq /usr/lib/jvm/*
 update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk1.7.0/bin/java" 1
 update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk1.7.0/bin/javac" 1
 update-alternatives --install "/usr/bin/javaws" "javaws" "/usr/lib/jvm/jdk1.7.0/bin/javaws" 1

--- a/ansible/roles/java/files/install_java.sh
+++ b/ansible/roles/java/files/install_java.sh
@@ -7,6 +7,7 @@ rm -rf /usr/lib/jvm/jdk1.7.0 || true
 rm -rf /usr/lib/jvm/jdk1.7.0_67 || true
 mv jdk1.7.0_67/ /usr/lib/jvm/
 ln -s /usr/lib/jvm/jdk1.7.0_67/ /usr/lib/jvm/jdk1.7.0
+chown cchq:cchq /usr/lib/jvm/*
 update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk1.7.0/bin/java" 1
 update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk1.7.0/bin/javac" 1
 update-alternatives --install "/usr/bin/javaws" "javaws" "/usr/lib/jvm/jdk1.7.0/bin/javaws" 1


### PR DESCRIPTION
@dannyroberts @wpride this changes the owner of the java installations to cchq instead of root. this is necessary for monitoring the formplayer application. the formplayer service is run by cchq, but in order to access JMX it needs to read a couple files within the java directory. if you don't know what jmx is (i didn't), it's the recommended way to implement monitoring in java applications. i'm still new to the technology and wrapping my head around it, but it's built into java, which is why the files are located in the java directory. from the docs:

> The JMX specification defines an architecture, the design patterns, the APIs, and the services for application and network management and monitoring in the Java programming language.

> Using JMX technology, a given resource is instrumented by one or more Java objects known as Managed Beans, or MBeans. These MBeans are registered in a core managed object server, known as an MBean server, that acts as a management agent and can run on most devices enabled for the Java programming language.

it's mostly managed by the java framework we're using for formplayer and there's almost no additional code we need to write at this time. see this other PR as well: https://github.com/dimagi/commcare-hq-deploy/pull/134
