### PR TITLE
Remove motech5 server

### DIFF
--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -32,6 +32,3 @@ nginx_sites:
      - name: /endos-dhis
        proxy_pass: http://motech1.internal.commcarehq.org:8080/endos-dhis
        proxy_read_timeout: 360s
-     - name: /possiblehealth
-       proxy_pass: http://motech5.internal.commcarehq.org:8080/possiblehealth
-       proxy_read_timeout: 360s


### PR DESCRIPTION
@sheelio motech5 isn't up, so it blocks nginx restarting.

@nickpell 