### PR TITLE
add script template for transferring export migration logs to s3

### DIFF
--- a/ansible/roles/pg_standby/templates/s3_migration_logs.py.j2
+++ b/ansible/roles/pg_standby/templates/s3_migration_logs.py.j2
@@ -1,0 +1,19 @@
+import sys
+import os
+import boto3
+
+if len(sys.argv) != 1:
+    raise Exception('usage is s3_migration_logs.py')
+
+log_dir = os.path.abspath('/opt/data/migration-logs')
+log_files = os.listdir(log_dir)
+
+s3 = boto3.client('s3', region_name='{{ aws_region }}')
+for log_filename in log_files:
+    file_path = os.path.join(log_dir, log_filename)
+    s3.upload_file(
+        file_path,
+        'dimagi-production-migration-logs',
+        log_filename,
+        ExtraArgs={'ServerSideEncryption':'AES256'}
+    )


### PR DESCRIPTION
@calellowitz @benrudolph 

This isn't complete yet as I'm not sure how to get this properly deployed with ansible. This script worked when running manually from the postgres user on hqdb0.