### PR TITLE
Set auto_create_index to false

### DIFF
--- a/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/config/elasticsearch.yml.j2
@@ -61,3 +61,6 @@ cloud:
     access_key: "{{ localsettings.AMAZON_S3_ACCESS_KEY }}"
     secret_key: "{{ localsettings.AMAZON_S3_SECRET_KEY }}"
     region: "{{ aws_region }}"
+
+# Only allow indices to be created by an explicit "create" command
+action.auto_create_index: false

--- a/ansible/vars/staging/staging_public.yml
+++ b/ansible/vars/staging/staging_public.yml
@@ -59,6 +59,8 @@ backup_postgres: False
 backup_es: False
 postgres_s3: False
 
+aws_region: 'us-east-1'
+
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 
 postgres_config:


### PR DESCRIPTION
I deployed this on staging already.  Tested it out by attempting to submit a doc via curl:
```
$ curl -XPUT 'http://es-server.example.com:9200/fakeindex/type1/1?pretty' -d'
{
    "test" : "Ethan is testing"
}'
```
This succeeded before the change, and fails after with an IndexMissingException.  I did confirm that we are still able to create indices the way we normally do (in python, `es.indices.create(index="fakeindex")`).

The rolling restart didn't work for me on staging (I got a "failed to connect" error) - I had to manually call the start command.  For this reason I'll do the restart for prod in the office while pairing just to make sure we minimize ES downtime.

@calellowitz @dannyroberts @snopoke