### PR TITLE
moving couch installs to encrypted drive

### DIFF
--- a/ansible/roles/couchdb/defaults/main.yml
+++ b/ansible/roles/couchdb/defaults/main.yml
@@ -4,3 +4,4 @@ couchdb_source_mirror: http://mirrors.ibiblio.org/apache/couchdb/source
 couchdb_version: 1.6.1
 couchdb_distro_filename: apache-couchdb-{{ couchdb_version }}.tar.gz
 couchdb_install_path: /usr/local/bin/couchdb
+couch_data_dir: {{ encrypted_root }}/couchdb

--- a/ansible/roles/couchdb/defaults/main.yml
+++ b/ansible/roles/couchdb/defaults/main.yml
@@ -4,4 +4,4 @@ couchdb_source_mirror: http://mirrors.ibiblio.org/apache/couchdb/source
 couchdb_version: 1.6.1
 couchdb_distro_filename: apache-couchdb-{{ couchdb_version }}.tar.gz
 couchdb_install_path: /usr/local/bin/couchdb
-couch_data_dir: {{ encrypted_root }}/couchdb
+couch_data_dir: '{{ encrypted_root }}/couchdb'

--- a/ansible/roles/couchdb/tasks/main.yml
+++ b/ansible/roles/couchdb/tasks/main.yml
@@ -64,6 +64,7 @@
     - /usr/local/var/lib/couchdb
     - /usr/local/var/run/couchdb
     - /usr/local/etc/couchdb/
+    - {{ couch_data_dir }}
 
 - name: Configure CouchDB as service
   file: src=/usr/local/etc/init.d/couchdb dest=/etc/init.d/couchdb state=link

--- a/ansible/roles/couchdb/tasks/main.yml
+++ b/ansible/roles/couchdb/tasks/main.yml
@@ -64,7 +64,7 @@
     - /usr/local/var/lib/couchdb
     - /usr/local/var/run/couchdb
     - /usr/local/etc/couchdb/
-    - {{ couch_data_dir }}
+    - '{{ couch_data_dir }}'
 
 - name: Configure CouchDB as service
   file: src=/usr/local/etc/init.d/couchdb dest=/etc/init.d/couchdb state=link

--- a/ansible/roles/couchdb/templates/local.ini.j2
+++ b/ansible/roles/couchdb/templates/local.ini.j2
@@ -10,6 +10,8 @@
 
 [couchdb]
 ;max_document_size = 4294967296 ; bytes
+database_dir = {{ couch_data_dir }}
+view_index_dir = {{ couch_data_dir }}
 
 [httpd]
 port = 5984


### PR DESCRIPTION
@nickpell @mkangia 
on monoliths (and other servers running couch) the data directory is not on the encrypted drive. This fixes that for new installs. I will migrate old ones.