### PR TITLE
Add Mikolo DHIS2 Server

### DIFF
--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -35,3 +35,6 @@ nginx_sites:
      - name: /possiblehealth
        proxy_pass: http://motech5.internal-va.commcarehq.org:8080/possiblehealth
        proxy_read_timeout: 360s
+     - name: /mikolo-dhis
+       proxy_pass: http://motech6.internal-va.commcarehq.org:8080/mikolo-dhis
+       proxy_read_timeout: 360s


### PR DESCRIPTION
This is a server that is needed for MOTECH / DHIS2 integration in Madagascar.   Can you review and deploy to the proxy server?

@emord @kaapstorm 