### PR TITLE
Allow vagrant user to clone commcare-hq-deploy

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -23,7 +23,7 @@ fi
 
 if [ ! -d ~/commcare-hq-deploy ]; then
     echo "Cloning commcare-hq-deploy..."
-    git clone git@github.com:dimagi/commcare-hq-deploy ~/commcare-hq-deploy
+    git clone https://github.com/dimagi/commcare-hq-deploy.git ~/commcare-hq-deploy
     if [ ! -d ~/commcare-hq ]; then
         # keep old commands working: create symlink to simulate cchq repo
         mkdir ~/commcare-hq


### PR DESCRIPTION
The vagrant user isn't going to be able to authenticate on GitHub. Clone using http so we only need read permissions. (This assumes we should be logging into vagrant boxes as vagrant ... and that we care about cloning commcare-hq-deploy, which afaik we won't really need on vagrant.)

@snopoke @millerdev 
