### PR TITLE
nginx config when fake_ssl_cert

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -24,8 +24,13 @@ server {
 {% endif %}
 
 {% if 'ssl' in item.server.listen %}
+  {% if fake_ssl_cert %}
+  ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+  ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+  {% else %}
   ssl_certificate {{ ssl_certs_dir }}/{{ nginx_ssl_cert }};
   ssl_certificate_key {{ ssl_keys_dir }}/{{ nginx_ssl_key }};
+  {% endif %}
 {% if nginx_ssl_protocols|default('') %}
   ssl_protocols {{ nginx_ssl_protocols }};
 {% endif %}


### PR DESCRIPTION
When fake_ssl_cert is true, nginx_ssl_(cert|key) won't be copied, resulting in an invalid nginx config. Instead of copying fake SSL certs, just point nginx at the ones it already has.

@snopoke cc @NoahCarnahan 
