### PR TITLE
Run initdb so that PG can create users immediately

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -75,6 +75,13 @@
   sudo_user: postgres
   service: name=postgresql state=started
 
+# Run initdb so that Postgres is ready to create users immediately
+- name: Initialise PostgreSQL
+  sudo_user: postgres
+  command: {{ postgres_install_dir }}/bin/initdb {{ postgresql_home }}
+  args:
+    creates: {{ postgresql_home }}/global/pg_filenode.map
+
 - name: Create PostgreSQL users
   sudo_user: postgres
   postgresql_user:

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -78,9 +78,9 @@
 # Run initdb so that Postgres is ready to create users immediately
 - name: Initialise PostgreSQL
   sudo_user: postgres
-  command: {{ postgres_install_dir }}/bin/initdb {{ postgresql_home }}
+  command: "{{ postgres_install_dir }}/bin/initdb {{ postgresql_home }}"
   args:
-    creates: {{ postgresql_home }}/global/pg_filenode.map
+    creates: "{{ postgresql_home }}/global/pg_filenode.map"
 
 - name: Create PostgreSQL users
   sudo_user: postgres


### PR DESCRIPTION
The first time this play is run, PostgreSQL is not yet ready to create users by the time the task is reached. If you run it a second time then the task succeeds. This initialises the "main" cluster now, so that users can be created immediately.

UNTESTED
