### PR TITLE
Fix proxy deploy

### DIFF
--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -10,7 +10,7 @@ nginx_sites:
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
    file_name: "{{ deploy_env }}_commcare"
-   listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env }}"
+   listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env else ''}}"
    server_name: "{{ SITE_HOST }}"
    client_max_body_size: 500m
    proxy_set_headers:


### PR DESCRIPTION
@calellowitz pulled out the import part from https://github.com/dimagi/commcarehq-ansible/pull/618/commits/bc9860bbdf992c9dcb5dcbdc25f7803baa1347ff This'll block any deploy proxy so it'd be nice to get it in sooner than the icds stuff