### PR TITLE
rate limit nginx

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -16,6 +16,10 @@ upstream {{ balancer.name }} {
 }
 {% endfor %}
 
+{% for zone in item.server.get('limit_req_zones', []) %}
+limit_req_zone {{ zone.get('zone', '$binary_remote_addr') }} zone={{ zone.name }}:{{ zone.size }} rate={{ zone.rate }};
+{% endfor %}
+
 server {
 
 {% if nginx_separate_logs_per_site == True %}
@@ -40,7 +44,7 @@ server {
 {% endif %}
 
 {% for k,v in item.server.iteritems() %}
-  {% if k.find('location') == -1 and k not in ['file_name', 'balancers', 'proxy_set_headers', 'upstream_port'] %}
+  {% if k.find('location') == -1 and k not in ['file_name', 'balancers', 'proxy_set_headers', 'upstream_port', 'limit_req_zones'] %}
   {{ k }} {{ v }};
   {% endif %}
 {% endfor %}
@@ -63,7 +67,7 @@ server {
     {% if location.get('is_internal', False) == True %}
         internal;
     {% endif %}
-    {% for x,y in location.iteritems() if x not in ['name', 'balancer', 'is_internal', 'proxy_set_headers'] %}
+    {% for x,y in location.iteritems() if x not in ['name', 'balancer', 'is_internal', 'proxy_set_headers', 'limit_reqs'] %}
         {{ x }} {{ y }};
     {% endfor %}
     {% if location.get('proxy_set_headers') %}
@@ -71,7 +75,9 @@ server {
         proxy_set_header {{ header }};
       {% endfor %}
     {% endif %}
-
+    {% for limit in location.get('limit_reqs', []) %}
+        limit_req zone={{ limit.zone_name }}{% if limit.get('burst') %} burst={{limit.burst}}{% endif %}{% if limit.get('nodelay') %} nodelay{% endif %};
+    {% endfor %}
   }
 {% endfor %}
 }

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -13,6 +13,7 @@ nginx_sites:
       port: "{{ formplayer_port }}"
    limit_req_zones:
     - name: "server_name"
+      zone: "$server_name"
       size: "10m"
       rate: "50r/s"
    file_name: "{{ deploy_env }}_cas_commcare"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -16,6 +16,10 @@ nginx_sites:
       zone: "$server_name"
       size: "10m"
       rate: "50r/s"
+    - name: "remote_ip_addr"
+      zone: "$binary_remote_addr"
+      size: "10m"
+      rate: "5r/s"
    file_name: "{{ deploy_env }}_cas_commcare"
    listen: "443 ssl default_server"
    server_name: "{{ CAS_SITE_HOST }}"
@@ -34,6 +38,9 @@ nginx_sites:
        limit_reqs:
          - zone_name: "server_name"
            burst: "50"
+           nodelay: True
+         - zone_name: "remote_ip_addr"
+           burst: "5"
            nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -11,6 +11,10 @@ nginx_sites:
     - name: "{{ deploy_env }}_cas_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
+   limit_req_zones:
+    - name: "server_name"
+      size: "10m"
+      rate: "50r/s"
    file_name: "{{ deploy_env }}_cas_commcare"
    listen: "443 ssl default_server"
    server_name: "{{ CAS_SITE_HOST }}"
@@ -26,6 +30,10 @@ nginx_sites:
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
+       limit_reqs:
+         - zone_name: "server_name"
+           burst: "50"
+           nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"
        add_header: "Access-Control-Allow-Origin *"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -37,10 +37,8 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "server_name"
-           burst: "0"
            nodelay: True
          - zone_name: "remote_ip_addr"
-           burst: "0"
            nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -15,7 +15,7 @@ nginx_sites:
     - name: "server_name"
       zone: "$server_name"
       size: "10m"
-      rate: "50r/s"
+      rate: "200r/s"
     - name: "remote_ip_addr"
       zone: "$binary_remote_addr"
       size: "10m"
@@ -37,10 +37,10 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "server_name"
-           burst: "50"
+           burst: "0"
            nodelay: True
          - zone_name: "remote_ip_addr"
-           burst: "5"
+           burst: "0"
            nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"


### PR DESCRIPTION
Tested this on staging with ethan also hitting the server.

This will rate limit based on the server name so "cas.commcarehq.org" (which I think is what all phones will be hitting) It doesn't seem necessary to block the main site as that's only used via the web correct? if that's necessary, It'll also take some refactoring as we use the same base yml file for prod, softalyer and icds

@snopoke 

@gcapalbo @benrudolph 