### PR TITLE
Keep riak-cs access logs for 1 year

### DIFF
--- a/ansible/deploy_riakcs.yml
+++ b/ansible/deploy_riakcs.yml
@@ -154,6 +154,6 @@
         user: root
         special_time: daily
         job: /usr/bin/find /var/log/riak-cs -name 'access.log.*' -mmin +90 -exec gzip -q {} \; &&
-             /usr/bin/find /var/log/riak-cs -name 'access.log.*' -mtime +31 -delete
+             /usr/bin/find /var/log/riak-cs -name 'access.log.*' -mtime +365 -delete
         cron_file: riak-cs-access-logs
         state: present


### PR DESCRIPTION
Occasionally riak has lost an object. This will allow us to better track how often this is happening. See https://manage.dimagi.com/default.asp?248739 for more details.

The size of compressed access logs for the past month is about 50MB, so this will increase the storage requirements to about 600MB.

@dannyroberts cc @kaapstorm @javierwilson @snopoke 