### PR TITLE
prioritize ucr pillows for icds

### DIFF
--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -291,14 +291,14 @@ localsettings:
             - 'location'
           include_ucrs:
             - 'static-awc_location'
-      - name: 'kafka-ucr-static-ccs_record_cases,'
+      - name: 'kafka-ucr-static-ccs_record_cases'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
           topics:
             - 'case-sql'
           include_ucrs:
-            - 'static-ccs_record_cases,'
+            - 'static-ccs_record_cases'
       - name: 'kafka-ucr-static-ccs_record_cases_monthly'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -283,26 +283,29 @@ localsettings:
   KAFKA_URL: "{{ groups.kafka.0 }}:9092"
   LOCAL_PILLOWS:
     icds:
-      - name: 'kafka-ucr-static-03'
+      - name: 'kafka-ucr-static-usage-forms'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          ucr_division: '03'
-      - name: 'kafka-ucr-static-47'
+          specific_ucr: 'static-usage_forms'
+      - name: 'kafka-ucr-static-child_cases_monthly_tableau'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          ucr_division: '47'
-      - name: 'kafka-ucr-static-8a'
+          specific_ucr: 'static-child_cases_monthly_tableau'
+      - name: 'kafka-ucr-static-ccs_record_cases_monthly_tableau'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          ucr_division: '8a'
-      - name: 'kafka-ucr-static-cf'
+          specific_ucr: 'static-ccs_record_cases_monthly_tableau'
+      - name: 'kafka-ucr-static-non-priority'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          ucr_division: 'cf'
+          exclude_ucrs:
+            - 'static-usage_forms'
+            - 'static-child_cases_monthly_tableau'
+            - 'static-ccs_record_cases_monthly_tableau'
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
   PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
   PG_DATABASE_NAME: commcarehq

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -283,29 +283,154 @@ localsettings:
   KAFKA_URL: "{{ groups.kafka.0 }}:9092"
   LOCAL_PILLOWS:
     icds:
-      - name: 'kafka-ucr-static-usage-forms'
+      - name: 'kafka-ucr-static-awc-location'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          specific_ucr: 'static-usage_forms'
-      - name: 'kafka-ucr-static-child_cases_monthly_tableau'
+          topics:
+            - 'location'
+          include_ucrs:
+            - 'static-awc_location'
+      - name: 'kafka-ucr-static-ccs_record_cases,'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          specific_ucr: 'static-child_cases_monthly_tableau'
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-ccs_record_cases,'
+      - name: 'kafka-ucr-static-ccs_record_cases_monthly'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-ccs_record_cases_monthly'
       - name: 'kafka-ucr-static-ccs_record_cases_monthly_tableau'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          specific_ucr: 'static-ccs_record_cases_monthly_tableau'
-      - name: 'kafka-ucr-static-non-priority'
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-ccs_record_cases_monthly_tableau'
+      - name: 'kafka-ucr-static-child_cases_monthly'
         class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
         instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
         params:
-          exclude_ucrs:
-            - 'static-usage_forms'
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-child_cases_monthly'
+      - name: 'kafka-ucr-static-child_health_cases'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-child_health_cases'
+      - name: 'kafka-ucr-static-child_cases_monthly_tableau'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'case-sql'
+          include_ucrs:
             - 'static-child_cases_monthly_tableau'
-            - 'static-ccs_record_cases_monthly_tableau'
+      - name: 'kafka-ucr-static-other-cases'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-household_cases'
+            - 'static-person_cases'
+            - 'static-tasks_cases'
+            - 'static-tech_issue_cases'
+      - name: 'kafka-ucr-static-child_delivery_forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-child_delivery_forms'
+      - name: 'kafka-ucr-static-daily_feeding_forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-daily_feeding_forms'
+      - name: 'kafka-ucr-static-gm_forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-gm_forms'
+      - name: 'kafka-ucr-static-home_visit_forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-home_visit_forms'
+      - name: 'kafka-ucr-static-infrastructure_form'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-infrastructure_form'
+      - name: 'kafka-ucr-static-ls_home_visit_forms_filled'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-ls_home_visit_forms_filled'
+      - name: 'kafka-ucr-static-thr_forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-thr_forms'
+      - name: 'kafka-ucr-static-usage_forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-usage_forms'
+      - name: 'kafka-ucr-static-vhnd_form'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-vhnd_form'
+      - name: 'kafka-ucr-static-other-forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-awc_mgt_forms'
+            - 'static-visitorbook_forms'
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
   PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
   PG_DATABASE_NAME: commcarehq


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/15479

This creates specific pillows for curs that are important for ICDS. @sheelio can you take a look at this list to make sure I got the important ones correct?

@snopoke May also be good to split the "non-priority" pillow into two or three, but I'm not familiar with specs on the ICDS machines, so I don't want to overwhelm them. I think we'll likely want (number of cores - 1 or 2) number of static pillows running.

I think I recall you mentioning that our web workers are underutilized. Maybe we could start one or two pillows on those as well?