### PR TITLE
mail relay configuration

### DIFF
--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -13,7 +13,7 @@
         dest: /etc/postfix/main.cf
         regexp: '^relayhost ='
         line: "relayhost = {{ mailrelay }}"
-      when: groups['mailrelay'] is defined
+      when: groups['mailrelay'] is defined and mailrelay is defined
 
 - name: "mail relay clients deploy"
   hosts: all:!mailrelay

--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -2,7 +2,8 @@
   hosts: all
   sudo: yes
   tasks:
-    - package: name=postfix state=present
+    - debconf: name=postfix question="postfix/main_mailer_type" value="'Internet Site'" vtype="string"
+    - apt: name=postfix state=present force=yes
 
 - name: "mail relay deploy"
   hosts: mailrelay

--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -13,8 +13,8 @@
       lineinfile:
         dest: /etc/postfix/main.cf
         regexp: '^relayhost ='
-        line: "relayhost = {{ mailrelay }}"
-      when: groups['mailrelay'] is defined and mailrelay is defined
+        line: "relayhost = {{ parent_mailrelay }}"
+      when: groups['mailrelay'] is defined and parent_mailrelay is defined
 
 - name: "mail relay clients deploy"
   hosts: all:!mailrelay

--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -1,0 +1,27 @@
+- name: "Install postfix"
+  hosts: all
+  sudo: yes
+  tasks:
+    - package: name=postfix state=present
+
+- name: "mail relay deploy"
+  hosts: mailrelay
+  sudo: yes
+  tasks:
+    - name: "sets our relayhost"
+      lineinfile:
+        dest: /etc/postfix/main.cf
+        regexp: '^relayhost ='
+        line: "relayhost = {{ mailrelay }}"
+      when: groups['mailrelay'] is defined
+
+- name: "mail relay clients deploy"
+  hosts: all:!mailrelay
+  sudo: yes
+  tasks:
+    - name: "sets external relayhost"
+      lineinfile:
+        dest: /etc/postfix/main.cf
+        regexp: '^relayhost ='
+        line: "relayhost = {{ groups['mailrelay'][0] }}"
+      when: groups['mailrelay'] is defined

--- a/ansible/inventories/development
+++ b/ansible/inventories/development
@@ -56,3 +56,6 @@ swap_size=100M
 
 [patch_clients]
 192.168.33.16
+
+[mailrelay]
+192.168.33.14

--- a/ansible/inventories/development
+++ b/ansible/inventories/development
@@ -58,4 +58,4 @@ swap_size=100M
 192.168.33.16
 
 [mailrelay]
-192.168.33.14
+192.168.33.14 parent_mailrelay=mail.example.org

--- a/ansible/inventories/development
+++ b/ansible/inventories/development
@@ -58,4 +58,4 @@ swap_size=100M
 192.168.33.16
 
 [mailrelay]
-192.168.33.14 parent_mailrelay=mail.example.org
+192.168.33.14 parent_mailrelay='mail.example.org'

--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -152,6 +152,8 @@ postgresql_dbs:
 #    shards: [400, 511]
 #  - name: "{{localsettings.UCR_DATABASE_NAME}}"
 
+mailrelay: 'relay.example.com'
+
 localsettings:
   ALLOWED_HOSTS:
     - localhost

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -219,9 +219,6 @@ site_locations:
     auth_basic: '"Restricted Content"'
     auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
 
-
-mailrelay: 'relay.nic.in'
-
 localsettings:
   ALLOWED_HOSTS:
     - localhost

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -220,6 +220,8 @@ site_locations:
     auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
 
 
+mailrelay: 'relay.nic.in'
+
 localsettings:
   ALLOWED_HOSTS:
     - localhost
@@ -262,7 +264,7 @@ localsettings:
   ELASTICSEARCH_HOST: "{{ groups.elasticsearch.0 }}"
   ELASTICSEARCH_PORT: '9200'
   EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
-  EMAIL_SMTP_HOST: 'relay.nic.in'
+  EMAIL_SMTP_HOST: 'localhost'
   EMAIL_SMTP_PORT: 25
   EMAIL_USE_TLS: no
   FORMPLAYER_URL: "/formplayer"


### PR DESCRIPTION
creates deploy_mailrelay that forces outbound email to go through the server defined at the "mailrelay" group (if defined at all)
also sets django mail server to localhost for ICDS (since we're taking care of thing at the MTA level)