### PR TITLE
Revert "no remote ip based rate limit"

### DIFF
--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -16,6 +16,10 @@ nginx_sites:
       zone: "$server_name"
       size: "10m"
       rate: "500r/s"
+    - name: "remote_ip_addr"
+      zone: "$binary_remote_addr"
+      size: "10m"
+      rate: "5r/s"
    file_name: "{{ deploy_env }}_cas_commcare"
    listen: "443 ssl default_server"
    server_name: "{{ CAS_SITE_HOST }}"
@@ -33,6 +37,8 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "server_name"
+           nodelay: True
+         - zone_name: "remote_ip_addr"
            nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#646

I think this should be reverted once the trainings are complete, so maybe a couple weeks?

@sravfeyn @calellowitz @benrudolph 