### PR TITLE
Remove run_once

### DIFF
--- a/ansible/group_vars/celery.yml
+++ b/ansible/group_vars/celery.yml
@@ -1,0 +1,1 @@
+datadog_integration_celery: true

--- a/ansible/roles/datadog/tasks/integrations.yml
+++ b/ansible/roles/datadog/tasks/integrations.yml
@@ -14,7 +14,6 @@
     sha256sum: "{{ datadog_celery_sha256sum }}"
     force: yes
   notify: restart datadog
-  run_once: true
   when: inventory_hostname == groups.celery[0]
 
 - name: add datadog integration configs

--- a/ansible/roles/datadog/tasks/integrations.yml
+++ b/ansible/roles/datadog/tasks/integrations.yml
@@ -36,3 +36,4 @@
     - datadog_integration_riakcs
     - datadog_integration_zk
     - datadog_integration_jmx
+    - datadog_integration_celery

--- a/ansible/roles/datadog/templates/celery.yaml.j2
+++ b/ansible/roles/datadog/templates/celery.yaml.j2
@@ -1,4 +1,4 @@
 init_config:
 
 instances:
-  - flower_url: http://localhost:5555
+  - flower_url: "{{ localsettings.CELERY_FLOWER_URL }}"


### PR DESCRIPTION
@dannyroberts either this is new functionality in 2.0 or we were getting lucky on prod. when `run_once` is specified, it only runs once even if it's skipped. so this never gets run unless celery is the first machine loaded

fyi: @emord @calellowitz 