### PR TITLE
datadog use pipelining (fails otherwise on ansible 2)

### DIFF
--- a/ansible/roles/datadog/tasks/main.yml
+++ b/ansible/roles/datadog/tasks/main.yml
@@ -32,12 +32,15 @@
     path: "{{ datadog_custom_dir }}"
 
 - name: Pull datadog parsers
+  become: true
+  become_user: "{{ cchq_user }}"
+  vars:
+    ansible_ssh_pipelining: true
   git:
     repo: "{{ datadog_parsers_repo }}"
     dest: "{{ datadog_parsers_dest }}"
     accept_hostkey: yes
     update: yes
-  sudo_user: "{{ cchq_user }}"
   notify: restart datadog
 
 - include: integrations.yml


### PR DESCRIPTION
datadog role will fail because of sudo_user in ansible 2, this fixes it.  this change however i have not actually tested on my dev environment. but since others almost identical have worked, i hope for the best!