### PR TITLE
adding auto compact to couch for the two bad databases

### DIFF
--- a/ansible/roles/couchdb/templates/local.ini.j2
+++ b/ansible/roles/couchdb/templates/local.ini.j2
@@ -22,8 +22,7 @@ bind_address = {{ groups['couchdb'][0] }}
 ;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 
 [compactions]
-commcarehq__synclogs = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]
-commcarehq__users = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]
 
 ; Uncomment next line to trigger basic-auth popup on unauthorized requests.
 ;WWW-Authenticate = Basic realm="administrator"

--- a/ansible/roles/couchdb/templates/local.ini.j2
+++ b/ansible/roles/couchdb/templates/local.ini.j2
@@ -22,8 +22,8 @@ bind_address = {{ groups['couchdb'][0] }}
 ;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 
 [compactions]
-commcarehq__synclogs = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
-commcarehq__users = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
+commcarehq__synclogs = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]
+commcarehq__users = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]
 
 ; Uncomment next line to trigger basic-auth popup on unauthorized requests.
 ;WWW-Authenticate = Basic realm="administrator"

--- a/ansible/roles/couchdb/templates/local.ini.j2
+++ b/ansible/roles/couchdb/templates/local.ini.j2
@@ -21,6 +21,10 @@ bind_address = {{ groups['couchdb'][0] }}
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 
+[compactions]
+commcarehq__synclogs = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
+commcarehq__users = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
+
 ; Uncomment next line to trigger basic-auth popup on unauthorized requests.
 ;WWW-Authenticate = Basic realm="administrator"
 


### PR DESCRIPTION
@benrudolph @emord 
Here is auto compaction for couch. when the data size is less 30% of the db or 40% of the view, it will trigger a compact but only between 11pm and 4am. I only did it for the dbs that we have seen get large, because it seems like wasted resources otherwise, but happy to make it the default for all databases.