### PR TITLE
fixes for new riak machine

### DIFF
--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -36,7 +36,7 @@ active_sites:
   riakcs: True
   cas_ssl: True
 
-riak_ring_size: 128
+riak_ring_size: 64
 
 riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
 riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
@@ -175,7 +175,7 @@ etc_host_lines:
   - '10.247.24.13		www.icds-cas.gov.in'
 etc_host_lines_removed: ['etc_host_lines']
 
-http_proxy_address: '10.247.63.132'
+http_proxy_address: '10.247.24.16'
 http_proxy_port: '3128'
 
 site_locations:


### PR DESCRIPTION
@javierwilson @millerdev cc: @dannyroberts (i think you did the initial setup on this)
When trying to spin up a new riak machine on icds today i discovered that despite our configuration, existing nodes had been created with a ring size of 64, so in order to allow the new node to join its ring size, and all other new nodes, had to be 64 as well. I know we had good reasons to use 128 at first so I am curious if we think this is a long term problem or manageable.