### PR TITLE
replacing root with cchq user in commcarehq role

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -63,19 +63,6 @@
       tags:
         - slow
       when: not testing|default(False)
-
-    - name: chown clone
-      become: true
-      become_user: "{{ cchq_user }}"
-      file:
-        path: "{{ item }}"
-        state: directory
-        owner: "{{ cchq_user }}"
-        group: "{{ cchq_user }}"
-        recurse: yes
-      with_items:
-        - "{{ code_source }}"
-        - "{{ virtualenv_source }}"
   when: not gitdir.stat.exists
 
 - name: Upgrade setuptools

--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -9,7 +9,7 @@
 #    state: absent
 
 - name: create required directories
-  sudo: yes
+  become: true
   file:
     path: "{{ item }}"
     owner: "{{ cchq_user }}"
@@ -38,19 +38,23 @@
         accept_hostkey: yes
         update: yes
       become: true
+      become_user: "{{ cchq_user }}"
       tags:
         - git
         - slow
 
     - name: Link source to code_home
       become: true
+      become_user: "{{ cchq_user }}"
       file:
         state: link
         src: "{{ code_source }}"
         dest: "{{ code_home }}"
 
+
     - name: install pip requirements
       become: true
+      become_user: "{{ cchq_user }}"
       with_items: commcarehq_requirements
       pip:
         requirements: "{{ code_home }}/requirements/{{ item }}"
@@ -61,6 +65,7 @@
 
     - name: chown clone
       become: true
+      become_user: "{{ cchq_user }}"
       file:
         path: "{{ item }}"
         state: directory


### PR DESCRIPTION
@emord @gcapalbo @kaapstorm cc: @benrudolph 
I switched these tasks back to the cchq user because otherwise the `current` symlink was owned by root which made cloning the virtualenv across releases fail.