### PR TITLE
no proxy for localhost, also allow ::1 to check status

### DIFF
--- a/ansible/roles/http_proxy/tasks/main.yml
+++ b/ansible/roles/http_proxy/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: No proxy for local IPs
   lineinfile:
     dest: "/etc/environment"
-    line: "{{ item }}={{ groups['all']|join(',') }},relay.nic.in,smsgw.sms.gov.in,icds-cas.gov.in"
+    line: "{{ item }}={{ groups['all']|join(',') }},127.0.0.1,localhost,relay.nic.in,smsgw.sms.gov.in,icds-cas.gov.in"
     regexp: "{{item }}="
     create: yes
     state: present

--- a/ansible/roles/nginx/templates/default.j2
+++ b/ansible/roles/nginx/templates/default.j2
@@ -7,7 +7,7 @@ server {
       stub_status on;
       access_log off;
       allow 127.0.0.1;
-      allow allow ::1;;
+      allow ::1;;
       deny all;
   }
 }

--- a/ansible/roles/nginx/templates/default.j2
+++ b/ansible/roles/nginx/templates/default.j2
@@ -7,6 +7,7 @@ server {
       stub_status on;
       access_log off;
       allow 127.0.0.1;
+      allow allow ::1;;
       deny all;
   }
 }


### PR DESCRIPTION
this allows datadog to collect data even if /etc/hosts translates localhost to ::1