### PR TITLE
Require burst

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -76,7 +76,7 @@ server {
       {% endfor %}
     {% endif %}
     {% for limit in location.get('limit_reqs', []) %}
-        limit_req zone={{ limit.zone_name }}{% if limit.get('burst') %} burst={{limit.burst}}{% endif %}{% if limit.get('nodelay') %} nodelay{% endif %};
+        limit_req zone={{ limit.zone_name }} burst={{limit.burst}}{% if limit.get('nodelay') %} nodelay{% endif %};
     {% endfor %}
   }
 {% endfor %}

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -33,7 +33,7 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "server_name"
-           burst: 1000
+           burst: 750
            nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -33,6 +33,7 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "server_name"
+           burst: 1000
            nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"


### PR DESCRIPTION
@emord I think this is what was causing the rate limit issues. 

> By default, the maximum burst size is equal to zero.

it still seems weird though... as soon as i added a burst size equal to the rate limit size, we stopped getting rate limiting errors