### PR TITLE
swappiness

### DIFF
--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -12,25 +12,25 @@
   tags: swap
 
 - name: Create swap space
-  sudo: yes
+  become: true
   command: fallocate -l {{ swap_size }} /swapfile
   when: swap_size is defined and not swapfile.stat.exists
   tags: swap
 
 - name: Set swap file mode
-  sudo: yes
+  become: true
   file: path=/swapfile state=file mode=600
   when: swap_size is defined and not swapfile.stat.exists
   tags: swap
 
 - name: Make swap
-  sudo: yes
+  become: true
   command: mkswap /swapfile
   when: swap_size is defined and not swapfile.stat.exists
   tags: swap
 
 - name: Add swap to fstab
-  sudo: yes
+  become: true
   lineinfile:
     dest: /etc/fstab
     regexp: "^/swapfile"
@@ -40,21 +40,22 @@
   tags: swap
 
 - name: Turn on swap
-  sudo: yes
+  become: true
   command: swapon -a
   when: swap_size is defined and not swapfile.stat.exists
   tags: swap
 
-- name: Set swapiness
-  sudo: yes
-  shell: echo 0 | sudo tee /proc/sys/vm/swappiness
-  when: swap_size is defined and not swapfile.stat.exists
+- sysctl:
+  name: vm.swappiness
+  value: 0
+  state: present
+  become: true
   tags: swap
 
 # below are commands to remove swap if swap_size is removed from the config
 
 - name: Remove swap from fstab
-  sudo: yes
+  become: true
   lineinfile:
     dest: /etc/fstab
     regexp: "^/swapfile "
@@ -63,13 +64,13 @@
   tags: swap
 
 - name: Turn swap off
-  sudo: yes
+  become: true
   shell: swapoff -a
   when: swap_size is not defined and swapfile.stat.exists
   tags: swap
 
 - name: Remove swap file
-  sudo: yes
+  become: true
   file: path=/swapfile state=absent
   when: swap_size is not defined and swapfile.stat.exists
   tags: swap

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -45,10 +45,11 @@
   when: swap_size is defined and not swapfile.stat.exists
   tags: swap
 
-- sysctl:
-  name: vm.swappiness
-  value: 0
-  state: present
+- name: Set swappiness
+  sysctl:
+    name: vm.swappiness
+    value: 0
+    state: present
   become: true
   tags: swap
 


### PR DESCRIPTION
@dimagi/scale-team possibly part of the cause of our disk latency issues. On NIC the swappiness was set to 60 so postgres/riak were using swap even when there are gigs of memory available....

I don't think there's anything wrong with always setting swap to 0 no matter what so, i've removed the when check. 

I'm also not clear why there's swap in the first place. There is no swap_size defined in the inventory which is why this was never being run

@calellowitz run this on the new machines (esp pg3) before you fully migrate the db

buddy @millerdev 