### PR TITLE
run swap role on all nodes

### DIFF
--- a/ansible/deploy_common.yml
+++ b/ansible/deploy_common.yml
@@ -22,3 +22,8 @@
   sudo: yes
   roles:
     - {role: datadog, tags: datadog, when: DATADOG_ENABLED}
+
+- name: Configure swap
+  hosts: all
+  roles:
+    - {role: swap}


### PR DESCRIPTION
This change will make the role run twice during `deploy_stack`, once in `deploy_common` and once in `deploy_riak`. Adds a few seconds to the run but that's all.