### PR TITLE
adding back max connection variable

### DIFF
--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -72,6 +72,7 @@ pgbouncer_default_pool: 390
 pgbouncer_reserve_pool: 5
 pgbouncer_pool_timeout: 1
 pgbouncer_pool_mode: transaction
+pgbouncer_max_connections: 1500
 
 formplayer_db_name: formplayer
 


### PR DESCRIPTION
@snopoke @javierwilson this was dropped in the reorganization of pg settings. noticed yesterday when migrating. considered also bumping up to 3500 since some machines are already there but figured that could be a different pr