### PR TITLE
reduce size of nginx logs

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -66,7 +66,7 @@
           path: "{{ log_home }}/*.log"
           options:
             - monthly
-            - size 1G
+            - size 750M
             - rotate 14
             - missingok
             - compress


### PR DESCRIPTION
hqproxy0 disk usage is > 85%, which we get alerted about. Log dir is 18G, total disk is 32G, so it's a significant portion.

Do you all think this is a reasonable response to that alert?