### PR TITLE
Endpoint rate limiting

### DIFF
--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -12,10 +12,6 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
    limit_req_zones:
-    - name: "authentication"
-      zone: "$server_name"
-      size: "10m"
-      rate: "500r/s"
     - name: "restore"
       zone: "$server_name"
       size: "10m"
@@ -43,19 +39,11 @@ nginx_sites:
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
-       limit_reqs:
-         - zone_name: "authentication"
-           burst: 750
-           nodelay: True
      - name: "/a/icds-cas/phone/keys"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
-       limit_reqs:
-         - zone_name: "authentication"
-           burst: 750
-           nodelay: True
      - name: "/a/icds-cas/phone/restore"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -12,22 +12,22 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
    limit_req_zones:
+    - name: "authentication"
+      zone: "$server_name"
+      size: "10m"
+      rate: "500r/s"
+    - name: "restore"
+      zone: "$server_name"
+      size: "10m"
+      rate: "100r/s"
+    - name: "submissions"
+      zone: "$server_name"
+      size: "10m"
+      rate: "100r/s"
     - name: "server_name"
       zone: "$server_name"
       size: "10m"
-      rate: "70r/s"
-    - name: "login"
-      zone: "$login"
-      size: "10m"
-      rate: "30r/s"
-    - name: "restore"
-      zone: "$restore"
-      size: "10m"
-      rate: "30r/s"
-    - name: "submissions"
-      zone: "$submissions"
-      size: "10m"
-      rate: "10r/s"
+      rate: "100r/s"
    file_name: "{{ deploy_env }}_cas_commcare"
    listen: "443 ssl default_server"
    server_name: "{{ CAS_SITE_HOST }}"
@@ -38,6 +38,41 @@ nginx_sites:
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:
+     - name: "/accounts/login"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
+       limit_reqs:
+         - zone_name: "authentication"
+           burst: 750
+           nodelay: True
+     - name: "/a/icds-cas/phone/keys"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
+       limit_reqs:
+         - zone_name: "authentication"
+           burst: 750
+           nodelay: True
+     - name: "/a/icds-cas/phone/restore"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
+       limit_reqs:
+         - zone_name: "restore"
+           burst: 100
+           nodelay: True
+     - name: "/a/icds-cas/receiver"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
+       limit_reqs:
+         - zone_name: "submissions"
+           burst: 0
      - name: /
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
@@ -45,40 +80,7 @@ nginx_sites:
        proxy_read_timeout: 900s
        limit_reqs:
          - zone_name: "server_name"
-           burst: 750
-           nodelay: True
-    - name: "/accounts/login"
-      balancer: "{{ deploy_env }}_cas_commcare"
-      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      limit_reqs:
-        - zone_name: "login"
-          nodelay: True
-    - name: "/a/icds-cas/login"
-      balancer: "{{ deploy_env }}_cas_commcare"
-      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      limit_reqs:
-        - zone_name: "login"
-          nodelay: True
-    - name: "/a/icds-cas/phone/restore"
-      balancer: "{{ deploy_env }}_cas_commcare"
-      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      limit_reqs:
-        - zone_name: "restore"
-          nodelay: True
-    - name: "/a/icds-cas/phone/receiver"
-      balancer: "{{ deploy_env }}_cas_commcare"
-      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      limit_reqs:
-        - zone_name: "submissions"
-          nodelay: True
+           burst: 0
      - name: "/static"
        alias: "{{ nginx_static_home }}"
        add_header: "Access-Control-Allow-Origin *"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -15,7 +15,19 @@ nginx_sites:
     - name: "server_name"
       zone: "$server_name"
       size: "10m"
-      rate: "500r/s"
+      rate: "70r/s"
+    - name: "login"
+      zone: "$login"
+      size: "10m"
+      rate: "30r/s"
+    - name: "restore"
+      zone: "$restore"
+      size: "10m"
+      rate: "30r/s"
+    - name: "submissions"
+      zone: "$submissions"
+      size: "10m"
+      rate: "10r/s"
    file_name: "{{ deploy_env }}_cas_commcare"
    listen: "443 ssl default_server"
    server_name: "{{ CAS_SITE_HOST }}"
@@ -35,6 +47,38 @@ nginx_sites:
          - zone_name: "server_name"
            burst: 750
            nodelay: True
+    - name: "/accounts/login"
+      balancer: "{{ deploy_env }}_cas_commcare"
+      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      limit_reqs:
+        - zone_name: "login"
+          nodelay: True
+    - name: "/a/icds-cas/login"
+      balancer: "{{ deploy_env }}_cas_commcare"
+      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      limit_reqs:
+        - zone_name: "login"
+          nodelay: True
+    - name: "/a/icds-cas/phone/restore"
+      balancer: "{{ deploy_env }}_cas_commcare"
+      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      limit_reqs:
+        - zone_name: "restore"
+          nodelay: True
+    - name: "/a/icds-cas/phone/receiver"
+      balancer: "{{ deploy_env }}_cas_commcare"
+      proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+      proxy_next_upstream_tries: 1
+      proxy_read_timeout: 900s
+      limit_reqs:
+        - zone_name: "submissions"
+          nodelay: True
      - name: "/static"
        alias: "{{ nginx_static_home }}"
        add_header: "Access-Control-Allow-Origin *"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -34,6 +34,16 @@ nginx_sites:
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:
+     - name: "/hq/multimedia/file"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
+     - name: "/a/icds-cas/apps/download"
+       balancer: "{{ deploy_env }}_cas_commcare"
+       proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
+       proxy_next_upstream_tries: 1
+       proxy_read_timeout: 900s
      - name: "/accounts/login"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"


### PR DESCRIPTION
Ran `awk -F\" '{print $2}' icds_cas_commcare-nginx_access.log* | awk '{print $2}' | cut -d/ -f 1,2,3,4,5 | sort | uniq -c | sort -nr` on the past two weeks of logs. Everything with > 1000 hits

```
21136256 /a/icds-cas/receiver/secure
4053911 /a/icds-cas/apps/download
1758144 /a/icds-cas/phone/restore
 740852 /hq/multimedia/file/CommCareAudio
 275377 /a/icds-cas/phone/keys
 243680 /hq/multimedia/file/CommCareImage
  39699 /a/icds-cas/receiver/9c3c742c280ef42b5a941496bb4de626
  24762 /accounts/login/
   6473 /hq/multimedia/file/CommCareVideo
   1345 /
   1329 /a/icds-cas/apps/dozZyXC.
```

Seems really strange that /hq/multimedia is being hit. I thought that those would only be hit on new installs and that all the phones had the app preinstalled. Either way it seems inefficient to have django handle those since they're just static files.

I'm also assuming /phone/keys is part of authentication.

Authentication and app installs are not rate limited
Restores are 100 r/s with 100 burst
Submissions are 100 r/s with 0 burst
Everything else is 100 r/s with 0 burst

@dimagi/scale-team 