### PR TITLE
Add group vars for riakcs_new to fix datadog on hosts in that group

### DIFF
--- a/ansible/group_vars/riakcs_new.yml
+++ b/ansible/group_vars/riakcs_new.yml
@@ -1,0 +1,6 @@
+#datavol_device=... # defined in commcare-hq/fab/inventories/* if applicable
+# http://docs.basho.com/riak/latest/ops/tuning/linux/#Storage-and-File-System-Tuning
+datavol_opts: barrier=0,data=writeback
+
+datadog_integration_riak: true
+datadog_integration_riakcs: true


### PR DESCRIPTION
This should prevent datadog reporting from stopping when run against hosts in `riakcs_new` group.

@snopoke @calellowitz @emord 