### PR TITLE
compact synclogs more

### DIFF
--- a/ansible/roles/couchdb/templates/local.ini.j2
+++ b/ansible/roles/couchdb/templates/local.ini.j2
@@ -22,6 +22,7 @@ bind_address = {{ inventory_hostname|ipaddr }}
 socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 
 [compactions]
+commcarehq__synclogs = [{db_fragmentation, "50%"}, {view_fragmentation, "50%"}, {from, "17:00"}, {to, "22:30"}]
 _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]
 
 ; Uncomment next line to trigger basic-auth popup on unauthorized requests.


### PR DESCRIPTION
@dimagi/scale-team 

Was looking at https://app.datadoghq.com/metric/explorer?live=true&page=0&is_auto=false&from_ts=1491675022153&to_ts=1494267022153&tile_size=m&exp_metric=couchdb.by_db.disk_size&exp_scope=&exp_group=db&exp_agg=avg&exp_row_type=metric#db:commcarehq_synclogs and saw that synclogs gets to almost 300 GB and hasn't been compacted ~1.5 weeks.

I think this should make compaction happen around every 4 days or so which seems better. Could probably do something more aggressive if we wanted as well