### PR TITLE
Allow executable

### DIFF
--- a/ansible/roles/shared_dir/tasks/setup_host.yml
+++ b/ansible/roles/shared_dir/tasks/setup_host.yml
@@ -6,7 +6,7 @@
     path: "{{ shared_data_dir }}"
     owner: "nobody"
     group: "{{ shared_dir_gid }}"
-    mode: "u=rwx,g=rwx,o=r"
+    mode: "u=rwx,g=rwx,o=rx"
     state: directory
   tags:
     - nfs
@@ -32,7 +32,7 @@
     path: "{{ item }}"
     owner: "nobody"
     group: "{{ shared_dir_gid }}"
-    mode: "u=rwx,g=rwx,o=r"
+    mode: "u=rwx,g=rwx,o=rx"
     state: directory
   with_items:
     - "{{ restore_payload_dir_host }}"


### PR DESCRIPTION
@millerdev @javierwilson was debugging why formplayer wasn't working on swiss. it turns it out it couldn't download the application because when it'd attempt to, the nginx worker (user `www-data`) didn't have permissions to open the file. you cannot read a file unless you have access to the dir, so i figured that was the intent of the permissions already