### PR TITLE
Increase swappiness to 1 because 0 disables swap

### DIFF
--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Set swappiness
   sysctl:
     name: vm.swappiness
-    value: 0
+    value: 1
     state: present
   become: true
   tags: swap


### PR DESCRIPTION
@millerdev not urgent to do for icds, but figured we should get all of our machines on a similar setup