### PR TITLE
set flower url for icds

### DIFF
--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -258,7 +258,7 @@ localsettings:
   BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
   BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
   BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
-  CELERY_FLOWER_URL: "" #"http://{{ groups.celery.0 }}:5555"
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
   CELERY_PERIODIC_QUEUE: 'celery_periodic'
   CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'


### PR DESCRIPTION
This is used by the datadog integration as well. We could separate it into 2 different settings but waiting on feedback from @dannyroberts as to why this was commented out in the first place: https://github.com/dimagi/commcarehq-ansible/commit/0481f094022826160469637bee036e12fcf80dc2