### PR TITLE
using pip for setuptools

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -74,9 +74,14 @@
   when: not gitdir.stat.exists
 
 - name: Upgrade setuptools
+  pip:
+    name: six
+    state: latest
+    virtualenv: "{{ virtualenv_home }}"
+- name: Upgrade setuptools
   easy_install:
-    # HACK: -U allows us to force update. In ansible 2.0 we can just use the state property
-    name: "-U setuptools"
+    name: setuptools
+    state: latest
     virtualenv: "{{ virtualenv_home }}"
 
 - name: copy localsettings


### PR DESCRIPTION
after failing to deploy common due to easy_install requiring six, i switched to pip and it did solve the problem. my guess is pip module works better than easy_install in ansible 2.