### PR TITLE
we don't need no java for web workers!

### DIFF
--- a/ansible/roles/webworker/meta/main.yml
+++ b/ansible/roles/webworker/meta/main.yml
@@ -2,5 +2,4 @@
 # roles/webworker/meta/main.yml
 
 dependencies:
-  - role: java
   - role: shared_dir


### PR DESCRIPTION
also, automatic download of JDK7 is broken, which pushed to review if installing java was absolutely needed.  Time for openjdk?