### PR TITLE
moving system scripts to /usr/local/sbin

### DIFF
--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -28,7 +28,7 @@
   sudo: yes
   template:
     src: "create_postgres_dump.sh.j2"
-    dest: "/etc/cron.d/create_postgres_dump.sh"
+    dest: "/usr/local/sbin/create_postgres_dump.sh"
     group: postgres
     owner: postgres
     mode: 0700
@@ -67,7 +67,7 @@
   sudo: yes
   template:
     src: "backup_snapshots.py.j2"
-    dest: "/etc/cron.d/backup_snapshots.py"
+    dest: "/usr/local/sbin/backup_snapshots.py"
     group: postgres
     owner: postgres
     mode: 0700
@@ -78,7 +78,7 @@
   sudo: yes
   cron:
     name: "Backup postgres daily"
-    job: "/etc/cron.d/create_postgres_dump.sh daily 3"
+    job: "/usr/local/sbin/create_postgres_dump.sh daily 3"
     minute: 0
     hour: 0
     weekday: "1,2,3,4,5,6"
@@ -90,7 +90,7 @@
   sudo: yes
   cron:
     name: "Backup postgres weekly"
-    job: "/etc/cron.d/create_postgres_dump.sh weekly 21"
+    job: "/usr/local/sbin/create_postgres_dump.sh weekly 21"
     minute: 0
     hour: 0
     weekday: 0
@@ -102,7 +102,7 @@
   sudo: yes
   template:
     src: "retrieve_backup.py.j2"
-    dest: "/root/retrieve_backup.py"
+    dest: "/usr/local/sbin/retrieve_backup.py"
     group: root
     owner: root
     mode: 0700
@@ -113,7 +113,7 @@
   sudo: yes
   template:
     src: "restore_from_backup.sh.j2"
-    dest: "/root/restore_from_backup.sh"
+    dest: "/usr/local/sbin/restore_from_backup.sh"
     group: root
     owner: root
     mode: 0700

--- a/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
+++ b/ansible/roles/pg_standby/templates/create_postgres_dump.sh.j2
@@ -5,12 +5,12 @@ DAYS_TO_RETAIN_BACKUPS=$2
 TODAY=$(date +"%Y_%m_%d")
 DIRECTORY="{{ postgresql_backup_dir }}/postgres_${BACKUP_TYPE}_${TODAY}"
 pg_basebackup -D $DIRECTORY -Xs
-tar -cjf "${DIRECTORY}.tar.bz" -C "${DIRECTORY}" .
+tar -czf "${DIRECTORY}.tar.gz" -C "${DIRECTORY}" .
 rm -rf $DIRECTORY
 
 # Remove old backups of this backup type
 find {{ postgresql_backup_dir }} -mtime "+$DAYS_TO_RETAIN_BACKUPS" -name "postgres_${BACKUP_TYPE}_*" -exec rm {} \;
 
 {% if postgres_s3 %}
-/etc/cron.d/backup_snapshots.py "${DIRECTORY}.tar.bz"
+/usr/local/sbin/backup_snapshots.py "${DIRECTORY}.tar.gz"
 {% endif %}

--- a/ansible/roles/pg_standby/templates/restore_from_backup.sh.j2
+++ b/ansible/roles/pg_standby/templates/restore_from_backup.sh.j2
@@ -11,7 +11,7 @@ if [ $confirm2 != 'y' ]; then
 fi
 
 echo 'retrieving backup from amazon'
-/root/retrieve_backup.py "${BACKUP}" &&
+/usr/local/sbin/retrieve_backup.py "${BACKUP}" &&
 
 echo 'extracting backup' &&
 tar -xjf "${BACKUP}" -C "{{ postgresql_backup_dir }}" &&


### PR DESCRIPTION
scripts should not live in /etc/cron.d, moving to /usr/local/sbin