### PR TITLE
chown link to ~/www/env/current to cchq

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -71,7 +71,15 @@
       with_items:
         - "{{ code_source }}"
         - "{{ virtualenv_source }}"
-        - "{{ code_home }}"
+
+    - name: chown current symlink
+      become: true
+      file:
+        path: "{{ code_home }}"
+        state: link
+        owner: "{{ cchq_user }}"
+        group: "{{ cchq_user }}"
+        recurse: yes
   when: not gitdir.stat.exists
 
 - name: Upgrade setuptools

--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -71,6 +71,7 @@
       with_items:
         - "{{ code_source }}"
         - "{{ virtualenv_source }}"
+        - "{{ code_home }}"
   when: not gitdir.stat.exists
 
 - name: Upgrade setuptools

--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -48,6 +48,8 @@
         state: link
         src: "{{ code_source }}"
         dest: "{{ code_home }}"
+        owner: "{{ cchq_user }}"
+        group: "{{ cchq_user }}"
 
     - name: install pip requirements
       become: true
@@ -72,14 +74,6 @@
         - "{{ code_source }}"
         - "{{ virtualenv_source }}"
 
-    - name: chown current symlink
-      become: true
-      file:
-        path: "{{ code_home }}"
-        state: link
-        owner: "{{ cchq_user }}"
-        group: "{{ cchq_user }}"
-        recurse: yes
   when: not gitdir.stat.exists
 
 - name: Upgrade setuptools


### PR DESCRIPTION
I had to do this manually on the last couple of deploys since the webworkers were redeployed @calellowitz and I tried to fix this before during the scale up but the PR had other issues. I think this should work correctly

@orangejenny 