### PR TITLE
mail relay deploy should be part of deploy_stack

### DIFF
--- a/ansible/deploy_stack.yml
+++ b/ansible/deploy_stack.yml
@@ -20,3 +20,4 @@
 - include: deploy_webworker.yml
 - include: deploy_touchforms.yml
 - include: deploy_formplayer.yml
+- include: deploy_mailrelay.yml


### PR DESCRIPTION
besides installing postfix, this tasks are only played if mailrelay group is defined. not including this in deploy_stack before is what left the new webworkes with no email communication enabled.