### PR TITLE
set celery timezone for ICDS

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -279,7 +279,7 @@ CELERY_SEND_TASK_ERROR_EMAILS = {{ localsettings.get('CELERY_SEND_TASK_ERROR_EMA
 CELERY_RESULT_BACKEND = '{{ localsettings.CELERY_RESULT_BACKEND }}'
 CELERY_PERIODIC_QUEUE = '{{ localsettings.CELERY_PERIODIC_QUEUE }}'
 CELERY_FLOWER_URL = '{{ localsettings.CELERY_FLOWER_URL }}'
-{% if CELERY_TIMEZONE in localsettings and localsettings.CELERY_TIMEZONE %}
+{% if 'CELERY_TIMEZONE' in localsettings and localsettings.CELERY_TIMEZONE %}
 CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
 {% endif %}
 

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -279,6 +279,9 @@ CELERY_SEND_TASK_ERROR_EMAILS = {{ localsettings.get('CELERY_SEND_TASK_ERROR_EMA
 CELERY_RESULT_BACKEND = '{{ localsettings.CELERY_RESULT_BACKEND }}'
 CELERY_PERIODIC_QUEUE = '{{ localsettings.CELERY_PERIODIC_QUEUE }}'
 CELERY_FLOWER_URL = '{{ localsettings.CELERY_FLOWER_URL }}'
+{% if CELERY_TIMEZONE in localsettings and localsettings.CELERY_TIMEZONE %}
+CELERY_TIMEZONE = '{{ localsettings.CELERY_TIMEZONE }}'
+{% endif %}
 
 {% if localsettings.get('CELERY_REMINDER_RULE_QUEUE') %}
 CELERY_REMINDER_RULE_QUEUE = '{{ localsettings.CELERY_REMINDER_RULE_QUEUE }}'

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -272,6 +272,7 @@ localsettings:
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
   CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
   CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CELERY_TIMEZONE: 'Asia/Kolkata'
   COMMCARE_HQ_NAME: 'ICDS-CAS Server'
   COMMCARE_NAME: 'ICDS-CAS'
   COUCH_CACHE_DOCS: True


### PR DESCRIPTION
I've tested this locally by finding the next fire time for a task which lined up with the scheduled time in IST.