### PR TITLE
roll couchdb2 logs

### DIFF
--- a/ansible/deploy_db.yml
+++ b/ansible/deploy_db.yml
@@ -58,6 +58,26 @@
   roles:
     - {role: couchdb2, tags: 'couchdb2'}
 
+- name: Couchdb2 log rolling configurations
+  hosts: couchdb2
+  sudo: yes
+  roles:
+    - role: ansible-logrotate
+      tags: couchdb2
+      logrotate_scripts:
+        - name: "{{ deploy_env }}_couchdb2"
+          path: "{{ couchdb_dir }}/var/log/*.stderr"
+          options:
+            - daily
+            - size 100M
+            - rotate 10
+            - missingok
+            - compress
+            - delaycompress
+            - copytruncate
+            - nocreate
+            - notifempty
+
 - name: Redis
   hosts: redis
   sudo: yes


### PR DESCRIPTION
Because an 11 GB log file is a bit much

@benrudolph any reason you put the couch 1 log rolling here? I just d this off of your work there

buddy @calellowitz 