### PR TITLE
fixing old mistake, http proxy for all

### DIFF
--- a/ansible/deploy_http_proxy.yml
+++ b/ansible/deploy_http_proxy.yml
@@ -1,5 +1,5 @@
 - name: http proxy for external calls
-  hosts: patch_clients
+  hosts: all
   sudo: yes
   roles:
     - http_proxy

--- a/ansible/inventories/development
+++ b/ansible/inventories/development
@@ -53,8 +53,5 @@ swap_size=100M
 [shared_dir_host]
 192.168.33.16
 
-[patch_clients]
-192.168.33.16
-
 [mailrelay]
 192.168.33.14 parent_mailrelay='mail.example.org'


### PR DESCRIPTION
no need for all:!patch, because even patch server itself can use this, upstream path is defined at squid.conf level