### PR TITLE
Set boto3 signature_version

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -163,12 +163,14 @@ S3_BLOB_DB_SETTINGS = {
     'url': '{{ s3_blob_db_url }}',
     'access_key': '{{ s3_blob_db_access_key }}',
     'secret_key': '{{ s3_blob_db_secret_key }}',
+    'config': {'signature_version': 's3'},
 }
 {% if 'BLOB_DB_MIGRATING_FROM_S3_TO_S3' in localsettings %}
 OLD_S3_BLOB_DB_SETTINGS = {
     'url': '{{ old_s3_blob_db_url }}',
     'access_key': '{{ old_s3_blob_db_access_key }}',
     'secret_key': '{{ old_s3_blob_db_secret_key }}',
+    'config': {'signature_version': 's3'},
 }
 BLOB_DB_MIGRATING_FROM_S3_TO_S3 = {{ localsettings.BLOB_DB_MIGRATING_FROM_S3_TO_S3 }}
 {% endif %}


### PR DESCRIPTION
No idea why this is necessary, but recently a new machine was allocated on softlayer and it refused to connect to Riak CS.

Error on get object: `ClientError: An error occurred (InvalidRequest) when calling the GetObject operation: The authorization mechanism you have provided (AWS4-HMAC-SHA256) is not supported.`

On comparing this new machine (pillow3) to an existing machine (db0) I noticed they had slightly different client configs:

```
pillow3:
In [31]: bu.meta.client.meta.config._user_provided_options
Out[31]:
{'connect_timeout': 60,
 'max_pool_connections': 10,
 'read_timeout': 60,
 'region_name': u'us-east-1',
 's3': None,
 'signature_version': 's3v4',
 'user_agent': 'Boto3/1.4.4 Python/2.7.6 Linux/4.4.0-71-generic Botocore/1.5.71 Resource'}

db0:
In [12]: bu.meta.client.meta.config._user_provided_options
Out[12]:
{'connect_timeout': 60,
 'max_pool_connections': 10,
 'read_timeout': 60,
 'region_name': None,
 's3': None,
 'signature_version': 's3',
 'user_agent': 'Boto3/1.4.4 Python/2.7.6 Linux/3.13.0-65-generic Botocore/1.5.35 Resource'}
```

Setting `signature_version` in the config fixed the issue.

@nickpell @javierwilson 