### PR TITLE
RFC 2142 mail aliases

### DIFF
--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -4,6 +4,8 @@
   tasks:
     - debconf: name=postfix question="postfix/main_mailer_type" value="Internet Site" vtype="string"
     - apt: name=postfix state=present force=yes
+  tags:
+    - postfix
 
 - name: "mail relay deploy"
   hosts: mailrelay
@@ -21,6 +23,8 @@
         regexp: '^mynetworks ='
         line: "mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 {{ groups['all']|join('/32 ') }}"
       when: groups['mailrelay'] is defined and parent_mailrelay is defined
+  tags:
+    - postfix
 
 - name: "mail relay clients deploy"
   hosts: all:!mailrelay
@@ -32,9 +36,13 @@
         regexp: '^relayhost ='
         line: "relayhost = {{ groups['mailrelay'][0] }}"
       when: groups['mailrelay'] is defined
+  tags:
+    - postfix
 
 - name: "reload postfix"
   hosts: all
   sudo: yes
   tasks:
     - service: name=postfix state=restarted enabled=yes
+  tags:
+    - postfix

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -128,3 +128,5 @@ datadog_integration_riakcs: false
 datadog_integration_zk: false
 datadog_integration_jmx: false
 datadog_integration_process: true
+
+root_email: commcarehq-ops+root@dimagi.com

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -89,4 +89,24 @@
     - hostname
     - after-reboot
 
+- name: "RFC 2142 email aliases and forwarding"
+  become: yes
+  template:
+    src: etc_aliases.j2
+    dest: /etc/aliases
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  register: aliases
+  tags:
+    - postfix
+
+- name: "RFC 2142 email aliases and forwarding (update)"
+  become: yes
+  command: postalias /etc/aliases
+  when: aliases.changed
+  tags:
+    - postfix
+
 - include: antivirus.yml

--- a/ansible/roles/common/templates/etc_aliases.j2
+++ b/ansible/roles/common/templates/etc_aliases.j2
@@ -1,0 +1,18 @@
+info: root
+marketing: root
+sales: root
+support: root
+abuse: root
+noc: root
+security: root
+postmaster: root
+hostmaster: root
+usenet: root
+news: root
+webmaster: root
+www: root
+uucp: root
+ftp: root
+{% if root_email is defined %}
+root: {{ root_email }}
+{% endif %}


### PR DESCRIPTION
this is also to catch cron errors and in general to avoid mail to root to get lonely in /var/spool/mail...