### PR TITLE
Keep fewer proxy logs around

### DIFF
--- a/ansible/deploy_proxy.yml
+++ b/ansible/deploy_proxy.yml
@@ -76,7 +76,7 @@
           options:
             - monthly
             - size 750M
-            - rotate 14
+            - rotate 5
             - missingok
             - compress
             - delaycompress


### PR DESCRIPTION
Softlayer's proxy was keeping 14 rotations for riak. seems excessive. not sure why the other proxy's have less rotations, but I think it's related to the logrotate not applying correctly

@calellowitz @millerdev 