### PR TITLE
Updated couch proxy to be on couch0.

### DIFF
--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -242,7 +242,7 @@ couchdb2:
 
 couch_dbs:
   default:
-    host: 10.247.24.13
+    host: 10.247.24.18
     port: 25984
     name: commcarehq
     username: "{{ localsettings_private.COUCH_USERNAME }}"


### PR DESCRIPTION
 couch0 has always been running nginx for couch2 because I set it up in case anything went wrong during the initial deploy. @dimagi/scale-team 