### PR TITLE
moving kafka logs to /opt/data/kafka

### DIFF
--- a/ansible/vars/softlayer/softlayer_public.yml
+++ b/ansible/vars/softlayer/softlayer_public.yml
@@ -142,6 +142,7 @@ AMQP_HOST: "{{ groups.rabbitmq.0 }}"
 AMQP_NAME: commcarehq
 
 kafka_broker_id: 0
+kafka_log_dir: '/opt/data/kafka'
 
 encrypted_root: /opt/data/ecrypt
 


### PR DESCRIPTION
applied for softlayer, i applied same solution we sued for icds, however, i think kafka "logs" should probably not be in the same diretory as kafka logs which should be moved back to /var/log/kafka