### PR TITLE
Je/utc

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -707,5 +707,5 @@ ASYNC_INDICATORS_TO_QUEUE = {{ localsettings.ASYNC_INDICATORS_TO_QUEUE }}
 
 {% if localsettings.get('OFF_PEAK_TIME') %}
 from datetime import time
-OFF_PEAK_TIME = (time(localsettings.OFF_PEAK_TIME[0]), time(localsettings.OFF_PEAK_TIME[1]))
+OFF_PEAK_TIME = (time({{ localsettings.OFF_PEAK_TIME[0] }}), time({{ localsettings.OFF_PEAK_TIME[1] }}))
 {% endif %}

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -376,8 +376,8 @@ localsettings:
             - 'static-vhnd_form'
             - 'static-visitorbook_forms'
   OFF_PEAK_TIME:
-    - 18
-    - 8
+    - 12
+    - 3
   OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
   PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
   PG_DATABASE_NAME: commcarehq


### PR DESCRIPTION
@dimagi/scale-team The celery worker schedules tasks based on IST, but I used `datetime.utcnow()` to do the comparison. 

Could possibly change the loader to use the timezone, but would have to be careful to get the celery setting instead of the server setting as the server is still in UTC

buddy @esoergel 