### PR TITLE
Restart ucr indicator queue every 20 min

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -110,3 +110,26 @@
   tags:
     - localsettings
     - hq-localsettings
+
+- name: Copy celery restart script
+  sudo: yes
+  template:
+    src: "restart_celery.sh.j2"
+    dest: "/root/restart_celery.sh"
+    group: root
+    owner: root
+    mode: 0700
+    backup: yes
+  tags:
+    - hq-cronjob
+
+- name: Create Cron job
+  sudo: yes
+  cron:
+    name: "Restart celery ucr indicator"
+    job: /root/restart_celery.sh
+    user: root
+    cron_file: restart_celery
+    minute: "*/20"
+  tags:
+    - hq-cronjob

--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -130,6 +130,6 @@
     job: /root/restart_celery.sh
     user: root
     cron_file: restart_celery
-    minute: "*/20"
+    minute: "20"
   tags:
     - hq-cronjob

--- a/ansible/roles/commcarehq/templates/restart_celery.sh.j2
+++ b/ansible/roles/commcarehq/templates/restart_celery.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/bash
+supervisorctl restart commcare-hq-icds-celery_ucr_indicator_queue_0


### PR DESCRIPTION
This is not a great solution but I've tried a few things with no success.

Added extra logging to the autoscaler and tried to force it to stay at max concurrency: https://github.com/dimagi/commcare-hq/compare/je/log-more-for-autoscaler

from the logs it appears that even when we tell celery to scale down, it ignores the request and keeps 16 workers up.  those workers eventually become idle and do nothing while the load goes down to 0.

restarting the queue works for now @gcapalbo 