### PR TITLE
cron task to start/stop celery queues

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -110,3 +110,37 @@
   tags:
     - localsettings
     - hq-localsettings
+
+- name: Copy celery time script
+  become: true
+  template:
+    src: "restart_celery.sh.j2"
+    dest: "{{ cchq_home }}/bin/{{ item.action }}_celery.sh"
+    owner: "{{ cchq_user }}"
+    group: "{{ cchq_user }}"
+    mode: 0700
+    backup: yes
+  with_items:
+    - { action: start}
+    - { action: stop}
+  tags:
+    - ucr-indicator-celery
+
+- name: Create Cron jobs
+  sudo: yes
+  cron:
+    name: "{{ item.action }} celery ucr indicator"
+    job: "{{ cchq_home }}/bin/{{ item.action }}_celery.sh"
+    user: cchq
+    cron_file: ucr-indicator-celery
+    hour: "{{ item.hour }}"
+    minute: "{{ item.minute }}"
+  with_items:
+    - action: start
+      hour: 12
+      minute: 30
+    - action: stop
+      hour: 2
+      minute: 30
+  tags:
+    - ucr-indicator-celery

--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -114,7 +114,7 @@
 - name: Copy celery time script
   become: true
   template:
-    src: "restart_celery.sh.j2"
+    src: "ucr_indicator_celery_queue.sh.j2"
     dest: "{{ cchq_home }}/bin/{{ item.action }}_celery.sh"
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"

--- a/ansible/roles/commcarehq/templates/ucr_indicator_celery_queue.sh.j2
+++ b/ansible/roles/commcarehq/templates/ucr_indicator_celery_queue.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo supervisorctl {{ item.action }} commcare-hq-icds-celery_ucr_indicator_queue_0


### PR DESCRIPTION
taking @gcapalbo idea from my other PR. this will start at 1230 UTC (1800 IST) and stop at 230UTC (8 IST)

could be dryer but I don't think this should last very long (or get deployed to other environments) because a deploy between those hours would start all of the queues. safe for now because we don't generally deploy during those times.