### PR TITLE
Added postgres stat tracking.

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -194,3 +194,12 @@
   shell: "{{postgres_install_dir}}/bin/psql -U postgres -p {{postgresql_port}} {{item.name}} -c \"GRANT USAGE on FOREIGN DATA WRAPPER plproxy to {{item.get('user', localsettings.PG_DATABASE_USER)}}\""
   when: (item.get('django_alias') == 'proxy' and item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
+
+- name: Enable query stat collection
+  become: yes
+  become_user: postgres
+  vars:
+    ansible_ssh_pipelining: true
+  shell: "{{postgres_install_dir}}/bin/psql -U postgres -p {{postgresql_port}} {{item.name}} -c \"CREATE EXTENSION IF NOT EXISTS pg_stat_statements\""
+  when: pg_query_stats and item.query_stats|default(False)
+  with_items: "{{ postgresql_dbs }}"

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -85,6 +85,12 @@ log_temp_files = 0
 
 track_functions = all
 
+{% if not is_pg_standby|default(false) and pg_query_stats|default(false) %}
+shared_preload_libraries = 'pg_stat_statements'
+pg_stat_statements.track = all
+pg_stat_statements.max = 10000
+track_activity_query_size = 2048
+{% endif %}
 
 # AUTOVACUUM PARAMETERS
 

--- a/ansible/vars/production/production_public.yml
+++ b/ansible/vars/production/production_public.yml
@@ -88,6 +88,7 @@ pgbouncer_default_pool: 290
 pgbouncer_reserve_pool: 5
 pgbouncer_pool_timeout: 1
 pgbouncer_pool_mode: transaction
+pg_query_stats: True
 
 formplayer_db_name: formplayer
 
@@ -120,6 +121,7 @@ postgresql_dbs:
     host: "{{ groups.postgresql.1 }}"
   - name: "{{localsettings.UCR_DATABASE_NAME}}"
     host: "{{ groups.postgresql.0 }}"
+    query_stats: True
   - name: "{{ formplayer_db_name }}"
     host: "{{ groups.postgresql.0 }}"
 

--- a/ansible/vars/staging/staging_public.yml
+++ b/ansible/vars/staging/staging_public.yml
@@ -72,33 +72,42 @@ pgbouncer_default_pool: 15
 pgbouncer_reserve_pool: 4
 pgbouncer_pool_timeout: 2
 pgbouncer_pool_mode: transaction
+pg_query_stats: True
 
 formplayer_db_name: formplayer
 
 postgresql_dbs:
   - django_alias: default
     name: "{{localsettings.PG_DATABASE_NAME}}"
+    query_stats: True
   - django_alias: proxy
     name: commcarehq_proxy
   - django_alias: p1
     name: commcarehq_p1
     shards: [0, 99]
+    query_stats: True
   - django_alias: p2
     name: commcarehq_p2
     shards: [100, 199]
+    query_stats: True
   - django_alias: p3
     name: commcarehq_p3
     shards: [200, 299]
+    query_stats: True
   - django_alias: p4
     name: commcarehq_p4
     shards: [300, 399]
+    query_stats: True
   - django_alias: p5
     name: commcarehq_p5
     shards: [400, 511]
+    query_stats: True
   - name: "{{localsettings.UCR_DATABASE_NAME}}"
+    query_stats: True
   - name: "{{ formplayer_db_name }}"
   - django_alias: "{{ localsettings.ICDS_UCR_TEST_DATABASE_ALIAS }}"
     name: "{{ localsettings.ICDS_UCR_TEST_DATABASE_ALIAS }}"
+    query_stats: True
 
 ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
 


### PR DESCRIPTION
@dimagi/scale-team resolving #843 

This enables postgres's extension to track statistics.

Ideally wanted to use https://github.com/ankane/pghero because it can suggest indexes for us. https://github.com/ankane/pghero/blob/master/guides/Suggested-Indexes.md

It can be used when attached to the vpn with:

`docker run -ti -e DATABASE_URL="postgres://<user>:<pass>@<db_ip>:6432/<db_name>" -p 8080:8080 ankane/pghero` 