### PR TITLE
tmpreaper for formplayer

### DIFF
--- a/ansible/group_vars/formplayer.yml
+++ b/ansible/group_vars/formplayer.yml
@@ -1,1 +1,4 @@
 datadog_integration_jmx: true
+
+tmpreaper_dirs: "{{ encrypted_root }}/formplayer" "/tmp/."
+tmpreaper_time: 7d

--- a/ansible/group_vars/formplayer.yml
+++ b/ansible/group_vars/formplayer.yml
@@ -1,4 +1,1 @@
 datadog_integration_jmx: true
-
-tmpreaper_dirs: "{{ encrypted_root }}/formplayer /tmp/."
-tmpreaper_time: 7d

--- a/ansible/group_vars/formplayer.yml
+++ b/ansible/group_vars/formplayer.yml
@@ -1,4 +1,4 @@
 datadog_integration_jmx: true
 
-tmpreaper_dirs: "{{ encrypted_root }}/formplayer" "/tmp/."
+tmpreaper_dirs: "{{ encrypted_root }}/formplayer /tmp/."
 tmpreaper_time: 7d

--- a/ansible/roles/formplayer/tasks/main.yml
+++ b/ansible/roles/formplayer/tasks/main.yml
@@ -10,7 +10,7 @@
   cron:
     name: "{{ item.name }}"
     special_time: daily
-    job: "tmpreaper {{ item.dir }} {{ item.time_spec }}"
+    job: "tmpreaper {{ item.time_spec }} {{ item.dir }}"
     user: root
     cron_file: purge_formplayer_files
   with_items:

--- a/ansible/roles/formplayer/tasks/main.yml
+++ b/ansible/roles/formplayer/tasks/main.yml
@@ -10,11 +10,12 @@
   cron:
     name: "{{ item.name }}"
     special_time: daily
-    job: "find {{ item.dir }} -maxdepth {{ item.maxdepth }} -type {{ item.type }}  -mtime +{{ item.max_age }} -delete"
+    job: "tmpreaper {{ item.dir }} {{ time_spec }}"
     user: root
     cron_file: purge_formplayer_files
   with_items:
-    - {name: 'Purge temp files', dir: "/tmp", max_age: 2, type: f, maxdepth: 1}
+    - {name: 'Purge temp files', dir: '/tmp', time_spec: '2d'}
+    - {name: 'Purge sqlite db files', dir: '{{ formplayer_data_dir }}', time_spec: '2d'}
 
 - name: Formplayer build dir
   file:

--- a/ansible/roles/formplayer/tasks/main.yml
+++ b/ansible/roles/formplayer/tasks/main.yml
@@ -10,7 +10,7 @@
   cron:
     name: "{{ item.name }}"
     special_time: daily
-    job: "tmpreaper {{ item.dir }} {{ time_spec }}"
+    job: "tmpreaper {{ item.dir }} {{ item.time_spec }}"
     user: root
     cron_file: purge_formplayer_files
   with_items:


### PR DESCRIPTION
@javierwilson @emord i tried using `tmpreaper` for this. i tested on staging doing `tmpreaper  7d /opt/data/formplayer` and checked the conf to make sure it updated correctly. i'm a little worried that using tmpreaper is too blunt. if formplayer gets deployed to a machine that needs a different config for tmpreaper than i'm not sure how we do that. this may make sense to use our old cron way of killing old files. what do you think?

cc: @proteusvacuum 