### PR TITLE
Cap ES at 30 GB

### DIFF
--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 elasticsearch_version: 1.7.3
 # https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#_give_half_your_memory_to_lucene
-# Either half the machines RAM or 32GB. Never want to go over 32GB
-elasticsearch_memory: "{{ [ansible_memory_mb.real.total // 2, 32000] | min }}m"
+# Either half the machines RAM or 30 GB. Never want to go over 30 GB
+elasticsearch_memory: "{{ [ansible_memory_mb.real.total // 2, 30000] | min }}m"
 elasticsearch_download_sha256: af517611493374cfb2daa8897ae17e63e2efea4d0377d316baa351c1776a2bca
 elasticsearch_home: "/opt/elasticsearch-{{ elasticsearch_version }}"
 elasticsearch_conf_dir: "/etc/elasticsearch-{{ elasticsearch_version }}"


### PR DESCRIPTION
the reason to not go over 32 GB is because that's when ES starts using 64 bit pointers. Due to overhead that actually happens at 30.5 GB, but apparently 30 GB is more common usage. Could have caused issues when our servers on icds had 64 GB (48 GB now)

@dimagi/scale-team 