### PR TITLE
fixes /etc/hosts bug

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,31 +1,8 @@
-- name: "Custom host file lines"
-  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{item}}" state=present
-  with_items: "{{ etc_host_lines }}"
-  when: etc_host_lines is defined
-  tags:
-    - etc_hosts
-
-- name: "Add host file"
-  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{item}}" state=present
-  with_items:
-    - "{{ lookup('dig', inventory_hostname, wantlist=True)[0] }}\t\t{{ inventory_hostname }}"
-  tags:
-    - etc_hosts
-  when: not inventory_hostname|ipaddr
-
-- name: "Remove lines from hosts file"
-  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{item}}" state=absent
-  with_items: "{{ etc_host_lines_removed }}"
-  when: etc_host_lines_removed is defined
-  tags:
-    - etc_hosts
-
 # For 12.04 Ubuntu, upgrade OpenSSL version
 - name: "Install libssl1.0.0"
   apt: name="libssl1.0.0" state=present
   tags:
     - upgrade_openssl
-
 
 - name: Hard file limits
   sudo: yes
@@ -39,7 +16,6 @@
   with_items:
     - '*'
     - 'root'
-
 
 - name: Soft file limits
   sudo: yes
@@ -95,9 +71,33 @@
     dest: /etc/hosts
     regexp: '^{{ ansible_default_ipv4.address }}\s'
     line: '{{ ansible_default_ipv4.address }} {{ hostname }}.{{ internal_domain_name }} {{ hostname }}'
-  when: hostname is defined and internal_domain_name is defined
+  when: hostname is defined and internal_domain_name is defined and not etc_hosts_lines|join(',')|search(ansible_default_ipv4.address)
   tags:
     - hostname
+    - after-reboot
+
+- name: "Custom host file lines"
+  lineinfile: dest=/etc/hosts regexp='^{{ item }}.*' line="{{item}}" state=present
+  with_items: "{{ etc_hosts_lines }}"
+  when: etc_hosts_lines is defined
+  tags:
+    - etc_hosts
+
+- name: "Add host file"
+  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{item}}" state=present
+  with_items:
+    - "{{ lookup('dig', inventory_hostname, wantlist=True)[0] }}\t\t{{ inventory_hostname }}"
+  tags:
+    - etc_hosts
+    - after-reboot
+  when: not inventory_hostname|ipaddr
+
+- name: "Remove lines from hosts file"
+  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{item}}" state=absent
+  with_items: "{{ etc_hosts_lines_removed }}"
+  when: etc_hosts_lines_removed is defined
+  tags:
+    - etc_hosts
     - after-reboot
 
 - name: "RFC 2142 email aliases and forwarding"

--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -8,8 +8,8 @@ internal_domain_name: 'localdomain'
 
 testing: True
 
-etc_host_lines: []
-etc_host_lines_removed: []
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
 # - "169.38.74.104   commcarehq-india.cloudant.com"
 
 http_proxy_address: '192.168.33.14'

--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -170,8 +170,8 @@ ufw_private_interface: eth0
 
 control_machine_ip: 172.25.3.5
 
-etc_host_lines: ['172.25.1.5 proxy0.enikshay.in proxy0 enikshay.in enikshay.commcarehq.org']
-etc_host_lines_removed: []
+etc_hosts_lines: ['172.25.1.5 enikshay.in enikshay.commcarehq.org']
+etc_hosts_lines_removed: []
 
 shared_drive_enabled: true
 

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -178,11 +178,11 @@ ufw_private_interface: eth0
 shared_drive_enabled: true
 
 # point hosts to the proxy machine
-etc_host_lines:
+etc_hosts_lines:
   - '10.247.24.13		cas.commcarehq.org'
   - '10.247.24.13		reports.icds-cas.gov.in'
   - '10.247.24.13		www.icds-cas.gov.in'
-etc_host_lines_removed: ['etc_host_lines']
+etc_hosts_lines_removed: []
 
 http_proxy_address: '10.247.24.16'
 http_proxy_port: '3128'

--- a/ansible/vars/production/production_public.yml
+++ b/ansible/vars/production/production_public.yml
@@ -145,8 +145,8 @@ AMQP_NAME: commcarehq
 
 ufw_private_interface: eth1
 
-etc_host_lines: []
-etc_host_lines_removed: []
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
 
 couch_dbs:
   default:

--- a/ansible/vars/softlayer/softlayer_public.yml
+++ b/ansible/vars/softlayer/softlayer_public.yml
@@ -150,8 +150,8 @@ ufw_private_interface: eth0
 
 control_machine_ip: 10.162.36.196
 
-etc_host_lines: []
-etc_host_lines_removed: []
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
 
 shared_drive_enabled: true
 

--- a/ansible/vars/staging/staging_public.yml
+++ b/ansible/vars/staging/staging_public.yml
@@ -122,8 +122,8 @@ AMQP_NAME: commcarehq
 
 ufw_private_interface: eth1
 
-etc_host_lines: []
-etc_host_lines_removed: []
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
 
 
 couch_dbs:


### PR DESCRIPTION
there was a (race) condition, where sometimes we would end up with /etc/hosts with no extra etc_hosts_lines, this fixes it skipping any host auto-definition if that hosts is included in an extra custom etc_hosts_line