### PR TITLE
set formplayer_purge_time_spec to 8d on enikshay and production

### DIFF
--- a/ansible/roles/formplayer/defaults/main.yml
+++ b/ansible/roles/formplayer/defaults/main.yml
@@ -2,3 +2,4 @@ formplayer_sentry_dsn: ''
 # define this to turn on archiving
 # (you can't use s for seconds, but m, h, d work for minute, hour, day)
 # formplayer_archive_time_spec: '10m'
+formplayer_purge_time_spec: '2d'

--- a/ansible/roles/formplayer/tasks/main.yml
+++ b/ansible/roles/formplayer/tasks/main.yml
@@ -15,7 +15,7 @@
     cron_file: purge_formplayer_files
   with_items:
     - {name: 'Purge temp files', dir: '/tmp', time_spec: '2d'}
-    - {name: 'Purge sqlite db files', dir: '{{ formplayer_data_dir }}', time_spec: '2d'}
+    - {name: 'Purge sqlite db files', dir: '{{ formplayer_data_dir }}', time_spec: '{{ formplayer_purge_time_spec }}'}
 
 - name: Create cron job to archive sqlite db files
   sudo: yes

--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -89,6 +89,7 @@ pg_query_stats: True
 
 formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
+formplayer_purge_time_spec: '8d'
 
 postgresql_dbs:
   - django_alias: default

--- a/ansible/vars/production/production_public.yml
+++ b/ansible/vars/production/production_public.yml
@@ -92,6 +92,7 @@ pg_query_stats: True
 
 formplayer_db_name: formplayer
 formplayer_archive_time_spec: '10m'
+formplayer_purge_time_spec: '8d'
 
 postgresql_dbs:
   - django_alias: default


### PR DESCRIPTION
Now with gzip archiving turned on, [production](https://app.datadoghq.com/dash/228649/formplayer-health?live=true&page=0&is_auto=false&from_ts=1503338161353&to_ts=1503942961353&tile_size=m&tpl_var_environment=production) and [enikshay](https://app.datadoghq.com/dash/228649/formplayer-health?live=true&page=0&is_auto=false&from_ts=1503338161353&to_ts=1503942961353&tile_size=m&tpl_var_environment=enikshay)'s formplayer data disks can very clearly support keeping these files around for a lot longer. You can see those disks are at 16-19%, and even if all of that were taken up by gzipped db files (they're not—there's also the commcare-hq releases which take up a fair amount of space, and of course the 10m worth of non-gzipped dbs), that's still a max of 75%, so space-wise this is quite safe.

The only objection I can think of is that it's actively harmful to let someone start from the data they had a week ago, since there's no auto-syncing in web-apps (right?) and it'd be easy for them to forget to sync but still think they had the latest info. Hopefully their training has taken care of that; if it hasn't, which is likely, I'd advocate for alerting the user if they haven't sync'd for a while.

The benefit of not deleting these is that I'd think that keeping syncs around longer and only having to do incremental syncs could both improve their user experience (no big sync that blocks you out for 10 minutes every time you log on in the morning), and also decreased load on HQ, since incremental syncs (I would think) are less intensive an operation.