### PR TITLE
postgres complains if recovery.conf is in config dir

### DIFF
--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -11,7 +11,7 @@
     state: directory
 
 - name: PostgreSQL recovery configuration
-  template: src=recovery.conf.j2 dest="{{ postgresql_dir_path }}/recovery.conf" owner="postgres"
+  template: src=recovery.conf.j2 dest="{{ postgresql_home }}/recovery.conf" owner="postgres" group="postgres"
   notify: Restart postgres
 
 - name: create backup directory

--- a/ansible/roles/pg_standby/tasks/main.yml
+++ b/ansible/roles/pg_standby/tasks/main.yml
@@ -11,7 +11,7 @@
     state: directory
 
 - name: PostgreSQL recovery configuration
-  template: src=recovery.conf.j2 dest="{{ postgresql_config_home }}/recovery.conf" owner="postgres"
+  template: src=recovery.conf.j2 dest="{{ postgresql_dir_path }}/recovery.conf" owner="postgres"
   notify: Restart postgres
 
 - name: create backup directory


### PR DESCRIPTION
@calellowitz this will require a change in the wiki instructions, apparently this change (not allowing recovery in config dir) came from ubuntu packaging see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853868

I blame Myon, from #postgresql:

<xocolatl> Myon: I wonder if pg_ctlcluster should error out if it finds a recovery.conf in /etc
<Myon> possibly, yes

@nickpell this solves the issue you encountered