### PR TITLE
Set celery timezone for enikshay

### DIFF
--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -218,6 +218,7 @@ localsettings:
   CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
   CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
   CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CELERY_TIMEZONE: 'Asia/Kolkata'
   COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
   COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
   COUCH_STALE_QUERY: 'update_after'


### PR DESCRIPTION
@javierwilson @mkangia @proteusvacuum 

I'm pulling this from the icds config https://github.com/dimagi/commcarehq-ansible/blob/master/ansible/vars/icds/icds_public.yml

I didn't notice anything going wrong, just thought this might be a better setting. I think without this the enikshay task [0] is running at midnight UTC (530 IST). this would cause it to run at midnight IST

buddy @sravfeyn 

[0] https://github.com/dimagi/commcare-hq/blob/af4c010ee38dfeda5e6149a880be374c9dd16843/custom/enikshay/tasks.py#L62