### PR TITLE
fixes duplicate line in enikshay public vars

### DIFF
--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -181,9 +181,6 @@ shared_drive_enabled: true
 # adding missing variables compared to icds 
 #http_proxy_address: '172.25.3.6' # use pg_standby as the patch server
 #http_proxy_port: '3128'
-ufw_private_interface: eth0
-
-
 
 couch_dbs:
   default:


### PR DESCRIPTION
getting rid of message: [WARNING] found a duplicate dict key (ufw_private_interface)