### PR TITLE
start riak after reboot

### DIFF
--- a/ansible/deploy_riakcs.yml
+++ b/ansible/deploy_riakcs.yml
@@ -83,7 +83,14 @@
         - "{{ riak_data_dir }}"
         - "{{ riak_ring_dir }}"
         - "{{ riak_data_root_leveldb }}"
-      when: _force_riak_config | bool
+      when: _force_riak_config|default(false) | bool
+
+- name: Start Riak
+  become: true
+  hosts: riakcs
+  tasks:
+    - service: name="riak" state=started enabled=yes
+      tags: after-reboot
 
 - name: Join Riak [CS] nodes to cluster
   become: true

--- a/ansible/roles/riakcs/install/tasks/main.yml
+++ b/ansible/roles/riakcs/install/tasks/main.yml
@@ -8,6 +8,7 @@
   register: riakcs_deb_check
   failed_when: false
   changed_when: false
+  tags: after-reboot
 
 - set_fact: riakcs_package_installed="{{ riakcs_deb_check.rc | default(0) == 0 }}"
 


### PR DESCRIPTION
after-reboot won't start riak because the whole "configuration and start riak" play is skipped, so I put this task separably. I am not sure it's the most elegant solution. opinions welcomed.