### PR TITLE
Update formplayer load balancing config for enikshay and cas endpoints

### DIFF
--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -11,6 +11,7 @@ nginx_sites:
     - name: "{{ deploy_env }}_cas_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
+      method: "hash $cookie_sessionid consistent"
    limit_req_zones:
     - name: "restore"
       zone: "$server_name"

--- a/ansible/roles/nginx/vars/enikshay_ssl.yml
+++ b/ansible/roles/nginx/vars/enikshay_ssl.yml
@@ -11,6 +11,7 @@ nginx_sites:
     - name: "{{ deploy_env }}_enikshay_formplayer"
       hosts: formplayer
       port: "{{ formplayer_port }}"
+      method: "hash $cookie_sessionid consistent"
    file_name: "{{ deploy_env }}_enikshay_commcare"
    listen: "443 ssl default_server"
    server_name: "{{ ENIKSHAY_SITE_HOST }}"


### PR DESCRIPTION
We had noticed this during the enikshay migration.

The endpoint this PR updates for enikshay is enikshay.commcarehq.org, and for icds is cas.commcarehq.org, and it only affects formplayer's use of these endpoints. I'm not sure what formplayer hits these endpoints for, but previously the load balancing it was using on softlayer was just a simple least connection load balancing. Is that a problem for formplayer? Wasn't sure if formplayer requests should consistently go to one machine because of the restore db. Note that this does not affect the normal site (enikshay.in / icds-cas.gov.in)

If so, then this PR will update it so that it uses a hash of the session id for load balancing rather than the least connection method, consistent with what we do for the main formplayer endpoint for enikshay.in / icds-cas.gov.in [here](https://github.com/dimagi/commcarehq-ansible/blob/gc/formplayer-mobile-endpoint/ansible/roles/nginx/vars/cchq_ssl.yml#L11)

Or, should we remove the formplayer site config for the enikshay.commcarehq.org and cas.commcarehq.org endpoints entirely if it's not used at all? Admitting I don't know enough about formplayer to say what's right here and just raising this as an inconsistency we should figure out.

@dannyroberts @wspride @emord @snopoke @ctsims 