### PR TITLE
Revert "cache prelogin pages"

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -25,13 +25,6 @@ proxy_cache_path {{ cache.path }} levels=1:2 keys_zone={{ cache.name }}:10m
                  max_size={{ cache.max_size}} inactive={{ cache.inactive_time }} use_temp_path=off;
 {% endfor %}
 
-{% if item.server.get('use_purge_method', False) == True %}
-map $request_method $purge_method {
-    PURGE 1;
-    default 0;
-}
-{% endif %}
-
 server {
 
 {% if nginx_separate_logs_per_site == True %}

--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -1,7 +1,6 @@
 ---
 nginx_sites:
 - server:
-   use_purge_method: True
    balancers:
     - name: "{{ deploy_env }}_commcare"
       hosts: webworkers
@@ -10,11 +9,6 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
-   proxy_cache_path:
-    - name: "prelogin_cache"
-      path: "{{ www_home }}/prelogin_cache"
-      max_size: "3g"
-      inactive_time: "24h"
    file_name: "{{ deploy_env }}_commcare"
    listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env else '' }}"
    root: "/var/www/html"
@@ -26,16 +20,6 @@ nginx_sites:
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:
-    - name: "~* ^(\/lang\/(\w+))?/(home|impact|pricing|services|software|solutions|askdemo)/$"
-      balancer: "{{ deploy_env }}_commcare"
-      proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"
-      proxy_next_upstream_tries: 1
-      proxy_read_timeout: 900s
-      proxy_cache: prelogin_cache
-      proxy_cache_use_stale: "error timeout updating http_500 http_502 http_503 http_504"
-      proxy_cache_methods: GET
-      add_header: X-Cache-Status $upstream_cache_status
-      proxy_cache_purge: "$purge_method"
     - name: /
       balancer: "{{ deploy_env }}_commcare"
       proxy_redirect: "http://{{ SITE_HOST }} https://{{ SITE_HOST }}"


### PR DESCRIPTION
Reverts dimagi/commcarehq-ansible#923

@biyeun I'm reverting this as it makes it is blocking proxy deploys due to the syntax error.

I'm also against pushing this to prod since it has a really long cache (24 hours) and it doesn't look like the documentation covers the full HTTP endpoints we'd need to hit to clear it