### PR TITLE
Add playbook to deploy chaos to host(s)

### DIFF
--- a/ansible/deploy_chaos.yml
+++ b/ansible/deploy_chaos.yml
@@ -10,8 +10,8 @@
 #
 # Variables can be set to tweak chaos settings. Examples:
 #
-#   Choose which chaos to install (currently only burnio)
-#   $ ap deploy_chaos.yml -e "hosts=webworkers enable=burnio" --tags=start
+#   Choose the chaos strategy (currently only burnio)
+#   $ ap deploy_chaos.yml -e "hosts=webworkers strategy=burnio" --tags=start
 #
 #   BurnIO wait 5s between burns
 #   $ ap deploy_chaos.yml -e "hosts=webworkers burnio_wait=5" --tags=start

--- a/ansible/deploy_chaos.yml
+++ b/ansible/deploy_chaos.yml
@@ -1,0 +1,23 @@
+# Deploy Chaos
+#
+# Usage:
+#
+#   Start chaos
+#   $ ap deploy_chaos.yml -e hosts=webworkers --tags=start
+#
+#   Stop chaos
+#   $ ap deploy_chaos.yml -e hosts=webworkers --tags=stop
+#
+# Variables can be set to tweak chaos settings. Examples:
+#
+#   Choose which chaos to install (currently only burnio)
+#   $ ap deploy_chaos.yml -e "hosts=webworkers enable=burnio" --tags=start
+#
+#   BurnIO wait 5s between burns
+#   $ ap deploy_chaos.yml -e "hosts=webworkers burnio_wait=5" --tags=start
+
+- name: chaos
+  hosts: "{{ hosts.split(',') }}"
+  become: true
+  roles:
+    - {role: chaos}

--- a/ansible/roles/chaos/defaults/main.yml
+++ b/ansible/roles/chaos/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+chaos_dir: /var/chaos
+
+# comma-delimited list of hosts for chaos (command line: -e hosts=webworkers)
+hosts: ''
+
+# comma-delimited list of enabled chaos strategies
+enable: "burnio"
+
+# wait time in seconds after each loop of burnio chaos
+burnio_wait: 0
+# directory in which to perform burnio chaos
+burnio_dir: /tmp

--- a/ansible/roles/chaos/defaults/main.yml
+++ b/ansible/roles/chaos/defaults/main.yml
@@ -4,8 +4,8 @@ chaos_dir: /var/chaos
 # comma-delimited list of hosts for chaos (command line: -e hosts=webworkers)
 hosts: ''
 
-# comma-delimited list of enabled chaos strategies
-enable: "burnio"
+# the chosen chaos strategy (see templates dir; currently this is the only one)
+strategy: "burnio"
 
 # wait time in seconds after each loop of burnio chaos
 burnio_wait: 0

--- a/ansible/roles/chaos/tasks/main.yml
+++ b/ansible/roles/chaos/tasks/main.yml
@@ -10,21 +10,18 @@
     - start
 
 - name: Install chaos scripts
-  sudo: yes
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ chaos_dir }}/start/{{ item }}"
+    src: "{{ strategy }}.j2"
+    dest: "{{ chaos_dir }}/start/{{ strategy }}"
     group: root
     owner: root
     mode: 0755
     backup: yes
-  with_items: "{{ enable.split(',') }}"
   tags:
     - start
 
 - name: Start chaos
-  shell: "{{ chaos_dir }}/start/{{ item }}"
-  with_items: "{{ enable.split(',') }}"
+  shell: "{{ chaos_dir }}/start/{{ strategy }}"
   tags:
     - start
 

--- a/ansible/roles/chaos/tasks/main.yml
+++ b/ansible/roles/chaos/tasks/main.yml
@@ -1,0 +1,50 @@
+# Chaos
+
+- name: Setup chaos directories
+  file: path="{{ item }}" owner=root group=root mode=0755 state=directory
+  with_items:
+    - "{{ chaos_dir }}"
+    - "{{ chaos_dir }}/start"
+    - "{{ chaos_dir }}/stop"
+  tags:
+    - start
+
+- name: Install chaos scripts
+  sudo: yes
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ chaos_dir }}/start/{{ item }}"
+    group: root
+    owner: root
+    mode: 0755
+    backup: yes
+  with_items: "{{ enable.split(',') }}"
+  tags:
+    - start
+
+- name: Start chaos
+  shell: "{{ chaos_dir }}/start/{{ item }}"
+  with_items: "{{ enable.split(',') }}"
+  tags:
+    - start
+
+- name: "Find stop scripts"
+  shell: "find {{ chaos_dir }}/stop -executable -type f"
+  register: stop_scripts
+  changed_when: false
+  failed_when: false
+  tags:
+    - debug_stop
+    - stop
+
+- name: Stop chaos
+  shell: "{{ item }}"
+  with_items: "{{ stop_scripts.stdout_lines }}"
+  tags:
+    - debug_stop
+    - stop
+
+- name: Remove chaos scripts
+  file: path="{{ chaos_dir }}" state=absent
+  tags:
+    - stop

--- a/ansible/roles/chaos/templates/burnio.j2
+++ b/ansible/roles/chaos/templates/burnio.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script for BurnIO Chaos
 #
-# based on https://github.com/Netflix/SimianArmy/blob/master/src/main/resources/scripts/burnio
+# based on https://github.com/Netflix/SimianArmy/blob/v2.5.0/src/main/resources/scripts/burnio.sh
 # see also https://github.com/Netflix/SimianArmy/wiki/The-Chaos-Monkey-Army#burn-io-simius-occupatus
 
 BURNFILE="{{ burnio_dir }}/burnio"

--- a/ansible/roles/chaos/templates/burnio.j2
+++ b/ansible/roles/chaos/templates/burnio.j2
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Script for BurnIO Chaos
+#
+# based on https://github.com/Netflix/SimianArmy/blob/master/src/main/resources/scripts/burnio
+# see also https://github.com/Netflix/SimianArmy/wiki/The-Chaos-Monkey-Army#burn-io-simius-occupatus
+
+BURNFILE="{{ burnio_dir }}/burnio"
+
+cat << EOF > {{ chaos_dir }}/burnioloop
+#!/bin/bash
+# do burnio chaos
+while true;
+do
+    dd if=/dev/urandom of=$BURNFILE bs=1M count=128 iflag=fullblock
+    sleep {{ burnio_wait }}
+done
+EOF
+
+cat << EOF > {{ chaos_dir }}/stop/burnio
+#!/bin/bash
+# stop burnio chaos
+killall -g burnioloop
+rm $BURNFILE
+EOF
+
+chmod +x {{ chaos_dir }}/burnioloop {{ chaos_dir }}/stop/burnio
+
+nohup {{ chaos_dir }}/burnioloop &


### PR DESCRIPTION
Currently only supports one type of chaos: BurnIO, which I'm hoping to use for IO load testing on web workers.

@calellowitz cc @javierwilson @emord 