### PR TITLE
Don't rate limit when users are submitting authorization

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -19,7 +19,7 @@ upstream {{ balancer.name }} {
 {% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {
   ""     $binary_remote_addr;
-  default     ""; 
+  default     "";
 }
 {% endfor %}
 
@@ -60,7 +60,7 @@ server {
 {% endif %}
 
 {% for k,v in item.server.iteritems() %}
-  {% if k.find('location') == -1 and k not in ['file_name', 'balancers', 'proxy_set_headers', 'upstream_port', 'limit_req_zones', 'proxy_cache_path'] %}
+  {% if k.find('location') == -1 and k not in ['file_name', 'balancers', 'proxy_set_headers', 'upstream_port', 'limit_req_zones', 'proxy_cache_path', 'mappings'] %}
   {{ k }} {{ v }};
   {% endif %}
 {% endfor %}

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -18,7 +18,7 @@ upstream {{ balancer.name }} {
 
 {% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {
-  ""     $binary_remote_addr;
+  ""     {{ var_map.value }};
   default     "";
 }
 {% endfor %}

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -16,7 +16,7 @@ upstream {{ balancer.name }} {
 }
 {% endfor %}
 
-{% for var_map in mappings %}
+{% for var_map in item.server.get('mappings', []) %}
 map {{ var_map.variable }} {{ var_map.name }} {
   ""     $binary_remote_addr;
   default     ""; 

--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -16,6 +16,13 @@ upstream {{ balancer.name }} {
 }
 {% endfor %}
 
+{% for var_map in mappings %}
+map {{ var_map.variable }} {{ var_map.name }} {
+  ""     $binary_remote_addr;
+  default     ""; 
+}
+{% endfor %}
+
 {% for zone in item.server.get('limit_req_zones', []) %}
 limit_req_zone {{ zone.get('zone', '$binary_remote_addr') }} zone={{ zone.name }}:{{ zone.size }} rate={{ zone.rate }};
 {% endfor %}

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -19,15 +19,19 @@ nginx_sites:
     - name: "restore"
       zone: "$server_name"
       size: "10m"
-      rate: "100r/s"
+      rate: "25r/s"
     - name: "submissions"
       zone: "$digest_submission"
       size: "10m"
-      rate: "200r/s"
+      rate: "20r/s"
     - name: "server_name"
       zone: "$server_name"
       size: "10m"
-      rate: "100r/s"
+      rate: "25r/s"
+    - name: "app_downloads"
+      zone: "$server_name"
+      size: "10m"
+      rate: "50r/s"
    proxy_cache_path:
     - name: "app_cache"
       path: "{{ www_home }}/app_downloads/cache"
@@ -55,12 +59,20 @@ nginx_sites:
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
        proxy_cache: app_cache
+       client_body_buffer_size: 5m
+       proxy_ignore_headers: Set-Cookie
      - name: "/a/icds-cas/apps/download"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
        proxy_cache: app_cache
+       client_body_buffer_size: 5m
+       proxy_ignore_headers: Set-Cookie
+       limit_reqs:
+        - zone_name: app_downloads
+          burst: 10
+          nodelay: True
      - name: "/accounts/login"
        balancer: "{{ deploy_env }}_cas_commcare"
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
@@ -85,6 +97,7 @@ nginx_sites:
        proxy_redirect: "http://{{ CAS_SITE_HOST }} https://{{ CAS_SITE_HOST }}"
        proxy_next_upstream_tries: 1
        proxy_read_timeout: 900s
+       client_body_buffer_size: 512k
        limit_reqs:
          - zone_name: "submissions"
            burst: 100

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -15,6 +15,7 @@ nginx_sites:
    mappings:
     - name: "$digest_submission"
       variable: "$http_authorization"
+      value: "$server_name"
    limit_req_zones:
     - name: "restore"
       zone: "$server_name"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -23,7 +23,7 @@ nginx_sites:
     - name: "submissions"
       zone: "$digest_submission"
       size: "10m"
-      rate: "20r/s"
+      rate: "10r/s"
     - name: "server_name"
       zone: "$server_name"
       size: "10m"

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -12,13 +12,16 @@ nginx_sites:
       hosts: formplayer
       port: "{{ formplayer_port }}"
       method: "hash $cookie_sessionid consistent"
+   mappings:
+    - name: "$digest_submission"
+      variable: "$http_authorization"
    limit_req_zones:
     - name: "restore"
       zone: "$server_name"
       size: "10m"
       rate: "100r/s"
     - name: "submissions"
-      zone: "$server_name"
+      zone: "$digest_submission"
       size: "10m"
       rate: "200r/s"
     - name: "server_name"

--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -13,7 +13,7 @@ nginx_sites:
    listen: "443 ssl{{ ' default_server' if deploy_env == primary_ssl_env else '' }}"
    root: "/var/www/html"
    server_name: "{{ SITE_HOST }}"
-   client_max_body_size: 500m
+   client_max_body_size: 600m
    proxy_set_headers:
    - "Host $host"
    - "X-Forwarded-For $remote_addr"


### PR DESCRIPTION
@dimagi/scale-team pretty sure this will let us not rate limit after a 401.

According to https://en.wikipedia.org/wiki/Digest_access_authentication the authorization header is only on the second request. 

basing the nginx config off of this https://serverfault.com/questions/784852/nginx-conf-for-limit-req-based-on-http-header

@snopoke @sravfeyn 