### PR TITLE
Update checkpoint parameters

### DIFF
--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -44,6 +44,8 @@ archive_timeout = 60
 
 wal_level = hot_standby
 max_wal_senders = 3
+checkpoint_segments = 16
+checkpoint_warning = 120s
 
 
 # REPLICATION

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -44,7 +44,7 @@ archive_timeout = 60
 
 wal_level = hot_standby
 max_wal_senders = 3
-checkpoint_segments = 16
+checkpoint_segments = {{ postgresql_checkpoint_segments|default(16) }}
 checkpoint_warning = 120s
 
 

--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -85,6 +85,7 @@ nofile_limit: 65536
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 
 postgresql_max_connections: 600
+postgresql_checkpoint_segments: 32
 pgbouncer_max_connections: 1600
 pgbouncer_default_pool: 500
 pgbouncer_reserve_pool: 5


### PR DESCRIPTION
https://www.postgresql.org/docs/9.4/static/wal-configuration.html

We currently use the default value of 3 for `checkpoint_segments` which means a checkpoint is performed every 3 WAL segments (or every `checkpoint_timeout` minutes, which ever comes first; `checkpoint_timeout` defaults to 5 minutes).

Checkpointing too frequently can have the side effect of producing more WAL output than is necessary as described in the link above. I think this is part of the reason for the issues with the enikshay location import process creating runaway WAL.

The downside to setting a higher value means that it would take more time to perform a recovery if the db crashed since it has more to replay since the last checkpoint.

I've also seen warnings in the ICDS logs saying that checkpoints are happening too frequently during times of heavy write usage on pg0, and setting a higher value should help reduce i/o load there too.

The update for `checkpoint_warning` to 120s from the default of 30s just means if checkpoints are performed less than that amount of time apart, a warning is written to the log.

@dimagi/scale-team 