### PR TITLE
pgbackrest: only keep WAL archives since last backup

### DIFF
--- a/ansible/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/ansible/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -31,6 +31,8 @@ backup-user=postgres
 {% endif %}
 repo-path={{ postgresql_backup_dir }}
 retention-full={{ postgresql_backup_weeks|default(4) }}
+retention-archive=1
+retention-archive-type=incr
 start-fast=y
 stop-auto=y
 compress-level=9


### PR DESCRIPTION
http://www.pgbackrest.org/configuration.html#section-expire

Our current pgbackrest config is archiving WAL logs and always keeping them around until the full backup they're associated with expires. This is causing us to run out of space on the enikshay standby and is limiting the number of backups we can actually store.

From my understanding this change should only keep the WAL archives since the last backup that happened (whether full, diff, or incr), which should help with the space issue. The downside is that we would only be able to do a point in time recovery (PITR) since the last backup. The upside is that we can store more backups.

I've already deployed this to enikshay since we're running out of space on the standby.

@javierwilson @snopoke 