### PR TITLE
Switch to using differential backups

### DIFF
--- a/ansible/roles/pgbackrest/tasks/main.yml
+++ b/ansible/roles/pgbackrest/tasks/main.yml
@@ -71,8 +71,8 @@
 - name: Create Daily Cron job
   sudo: yes
   cron:
-    name: "Backup postgres daily (incremental)"
-    job: "/usr/bin/pgbackrest --type=incr --stanza=backup backup"
+    name: "Backup postgres daily (differential)"
+    job: "/usr/bin/pgbackrest --type=diff --stanza=backup backup"
     minute: 0
     hour: "{{ nadir_hour|default(0) }}"
     weekday: "1,2,3,4,5,6"
@@ -83,8 +83,8 @@
 - name: Create Daily Cron job S3
   sudo: yes
   cron:
-    name: "Backup postgres daily (incremental) S3"
-    job: "/usr/bin/pgbackrest --type=incr --stanza=backups3 backup"
+    name: "Backup postgres daily (differential) S3"
+    job: "/usr/bin/pgbackrest --type=diff --stanza=backups3 backup"
     minute: 0
     hour: "{{ nadir_hour|default(0) }}"
     weekday: "1,2,3,4,5,6"

--- a/ansible/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/ansible/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -30,6 +30,7 @@ backup-host={{ hot_standby_server }}
 backup-user=postgres
 {% endif %}
 repo-path={{ postgresql_backup_dir }}
+retention-diff={{ postgresql_backup_days|default(3) }}
 retention-full={{ postgresql_backup_weeks|default(4) }}
 start-fast=y
 stop-auto=y


### PR DESCRIPTION
From what I'm seeing on enikshay, the incremental backups are taking up almost the same amount of room as the the full backups (looking at `repository backup size` in `pgbackrest info`).

I also don't see a way to expire incremental backups until the full backups they depend on expire, so this is causing us to run out of space on the standby machine unless we aggressively expire full backups.

What I'm proposing is that we switch from using incremental backups to differential backups so that we can use `retention-diff` to expire them. With this approach, based on our default settings in our ansible repo, we would then keep 4 weeks of weekly backups (`retention-full`) and 3 days of daily backups (`retention-diff`), mimicking the old pg basebackup method.

@javierwilson @snopoke 