### PR TITLE
stop wal archiving

### DIFF
--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -36,10 +36,6 @@ vacuum_cost_delay = 20ms
 
 # WRITE AHEAD LOG
 
-archive_mode = on
-archive_command = 'test ! -f {{ postgresql_archive_dir }}/%f && cp %p {{ postgresql_archive_dir }}/%f'
-archive_timeout = 60
-
 wal_level = hot_standby
 max_wal_senders = 3
 checkpoint_segments = {{ postgresql_checkpoint_segments|default(16) }}


### PR DESCRIPTION
@snopoke @javierwilson cc: @kaapstorm 
The replication slots should ensure the correct number of WAL logs (i know thats redundant but it sounds better in my head) are kept for the standby, and nothing currently cleans up our WAL archive, which means these continue to pile up and have almost filled the disks on 3 of our machines. There is also nothing configured to read from this archive so it doesn't seem to serve much purpose. The postgres docs seem to imply that replication slots supersede WAL archiving for standbys.

Longer term if we want to keep this, it should be possible to properly cleanup but in the short term i think it makes more sense to get rid of it until we have a plan on what to do with it.