### PR TITLE
couch_dbs now run on 15984

### DIFF
--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -186,14 +186,14 @@ couchdb2:
 couch_dbs:
   default:
     host: "{{ groups.couchdb2.0 }}"
-    port: 5984
+    port: 15984
     name: commcarehq
     username: "{{ localsettings_private.COUCH_USERNAME }}"
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: False
   users:
     host: "{{ groups.couchdb2.0 }}"
-    port: 5984
+    port: 15984
     name: commcarehq__users
     username: "{{ localsettings_private.COUCH_USERNAME }}"
     password: "{{ localsettings_private.COUCH_PASSWORD }}"


### PR DESCRIPTION
Hey @snopoke , it looks like couchdb2 should now be on 15984. am i reading this right?