### PR TITLE
Postgres logging

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -20,7 +20,6 @@
 
 - name: generate en_US.UTF-8 locale
   locale_gen: name='en_US.UTF-8' state=present
-
 - name: Install PostgreSQL & dependencies
   apt: name="{{ item }}" state=present
   with_items:
@@ -261,3 +260,26 @@
   shell: "{{postgres_install_dir}}/bin/psql -U postgres -p {{postgresql_port}} {{item.name}} -c \"CREATE EXTENSION IF NOT EXISTS pg_stat_statements\""
   when: pg_query_stats|default(False) and item.query_stats|default(False) and not is_pg_standby|default(False) and (item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
+
+- name: Copy log rotation script
+  become: yes
+  template:
+    src: "rotate_logs.sh.j2"
+    dest: "/usr/local/sbin/rotate_postgres_logs.sh"
+    group: postgres
+    owner: postgres
+    mode: 0700
+    backup: yes
+  tags:
+    - cron
+
+- name: Create log rotation cron
+  become: yes
+  cron:
+    name: "Rotate postgres logs"
+    job: "/usr/local/sbin/rotate_postgres_logs.sh"
+    minute: "*/15"
+    user: postgres
+    cron_file: rotate_postgres
+  tags:
+    - cron

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -61,10 +61,10 @@ effective_cache_size = {{ postgresql_effective_cache_size }}
 log_destination = 'csvlog'
 logging_collector = on
 log_directory = 'pg_log'
-log_filename = 'postgresql-%a.log'
+log_filename = 'postgresql-%x-%r.log'
 log_truncate_on_rotation = on
-log_rotation_age = 1d
-log_rotation_size = 0
+log_rotation_age = 0
+log_rotation_size = 100000
 
 client_min_messages = notice
 log_min_messages = warning

--- a/ansible/roles/postgresql/templates/rotate_logs.sh.j2
+++ b/ansible/roles/postgresql/templates/rotate_logs.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+# keep latest 20 log files 
+find {{ postgresql_home }}/pg_log -type f -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -20 | cut -d $'\t' -f 2- | xargs -d '\n' rm --
+
+# gzip all files except for the most recent 3
+find {{ postgresql_home }}/pg_log -type f -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -3 | cut -d $'\t' -f 2- | xargs -d '\n' gz --


### PR DESCRIPTION
https://trello.com/c/7OWkUCFl/173-improve-postgres-log-rotation-to-avoid-disk-filling-up

@calellowitz @snopoke @javierwilson A starting point for this. I haven't fully tested it being deployed, but think the basic idea is here. Workflow will be

1) postgres starts logging to files with the format postgresql-timestamp.log
2) postgres starts writing to a new log file after 100 MB
3) Every 15 minutes a script runs:
  a) it removes the the log files except for the 20 newest ones
  b) out of those 20 it gzips the 17 newest ones

Can easily change the 100 MB / 20 log files, but wasn't sure how much we want to keep around

buddy @mkangia 