### PR TITLE
Removed always_run usage.

### DIFF
--- a/ansible/roles/nginx/tasks/restart.yml
+++ b/ansible/roles/nginx/tasks/restart.yml
@@ -3,7 +3,7 @@
   become: yes
   shell: "nginx -t"
   register: result
-  always_run: true
+  check_mode: no
   failed_when: "result.rc != 0"
 
 - name: start the nginx service


### PR DESCRIPTION
```
TASK [nginx : check nginx configuration] ***************************************
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```

@snopoke 