### PR TITLE
Change couchbd2 compaction

### DIFF
--- a/ansible/roles/couchdb2/vars/main.yml
+++ b/ansible/roles/couchdb2/vars/main.yml
@@ -15,7 +15,6 @@ couchdb_parent_srcs_dir: /usr/local/couchdb2/src
 couchdb_init: 'sysv'
 
 couchdb_compaction_settings:
-  commcarehq__synclogs: '[{db_fragmentation, "25%"}, {view_fragmentation, "25%"}, {from, "17:00"}, {to, "22:30"}]'
-  _default: '[{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "17:00"}, {to, "22:30"}]'
+  _default: '[{db_fragmentation, "10%"}, {view_fragmentation, "10%"}, {from, "17:00"}, {to, "22:30"}]'
 
 couchdb_async_io_threads: 64


### PR DESCRIPTION
We've had enough issues with synclogs not compacting that I'm not convinced this works, so I'm thinking about changing all of these to 10% which means that once the file size is 10% more than the data size it will compact. this should not really affect other dbs that much since they have a lot less data than synclogs. thoughts?

@dannyroberts @snopoke 