### PR TITLE
add package sysstat to common installs

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -52,6 +52,7 @@
     - nodejs
     - at
     - screen
+    - sysstat
     - gettext
     - python-software-properties
     - mosh


### PR DESCRIPTION
adding sysstat to our base os installs so we can gather better metrics on IO