### PR TITLE
Fix postgres rotation script

### DIFF
--- a/ansible/roles/postgresql/templates/rotate_logs.sh.j2
+++ b/ansible/roles/postgresql/templates/rotate_logs.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 # keep latest 20 log files 
-find {{ postgresql_home }}/pg_log -type f -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -20 | cut -d $'\t' -f 2- | xargs -d '\n' rm --
+find {{ postgresql_home }}/pg_log/*.csv -type f -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -20 | cut -d $'\t' -f 2- | xargs -d '\n' rm
 
 # gzip all files except for the most recent 3
-find {{ postgresql_home }}/pg_log -type f -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -3 | cut -d $'\t' -f 2- | xargs -d '\n' gz --
+find {{ postgresql_home }}/pg_log/*.csv -type f -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -3 | cut -d $'\t' -f 2- | xargs -d '\n' gzip


### PR DESCRIPTION
@snopoke @javierwilson this is spamming emails. there's not really an issue with that, it just means these aren't getting removed/gzipped today. apparently I had an alias for gz locally. it should be gzip.