### PR TITLE
Remove 'remove lessc' task

### DIFF
--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -90,7 +90,7 @@
   become: yes
 
 - name: Remove lessc directory
-  - file:
+  file:
     path: /opt/lessc
     state: absent
 

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -78,7 +78,7 @@
   become: yes
   with_items:
     - npm@3.6.0
-    - less@1.3.1
+    - less@2.7.2
     - n@1.3.0
     - bower@1.5.3
     - uglify-js@2.6.1

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -85,16 +85,14 @@
   tags:
     - npm
 
-- name: Remove lessc directory
-  path: /opt/lessc
-  state: absent
-
 - name: Update Node
   command: 'n 0.10.29'
   become: yes
 
-- stat: path=/opt/lessc
-  register: lessc_stat
+- name: Remove lessc directory
+  - file:
+    path: /opt/lessc
+    state: absent
 
 - name: Install pip packages
   pip: name="{{ item }}"

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -85,6 +85,10 @@
   tags:
     - npm
 
+- name: Remove lessc directory
+  path: /opt/lessc
+  state: absent
+
 - name: Update Node
   command: 'n 0.10.29'
   become: yes

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -89,11 +89,6 @@
   command: 'n 0.10.29'
   become: yes
 
-- name: Remove lessc directory
-  file:
-    path: /opt/lessc
-    state: absent
-
 - name: Install pip packages
   pip: name="{{ item }}"
   become: yes

--- a/ansible/roles/common_installs/tasks/main.yml
+++ b/ansible/roles/common_installs/tasks/main.yml
@@ -92,12 +92,6 @@
 - stat: path=/opt/lessc
   register: lessc_stat
 
-- name: Install lessc from source
-  become: yes
-  # this is lessc 1.7.3
-  git: repo='https://github.com/less/less.js.git' dest='/opt/lessc' version='546bedd' recursive=yes accept_hostkey=yes
-  when: not lessc_stat.stat.exists
-
 - name: Install pip packages
   pip: name="{{ item }}"
   become: yes


### PR DESCRIPTION
Branched off of https://github.com/dimagi/commcarehq-ansible/pull/1019, only the last commit is new.

Can be merged once https://github.com/dimagi/commcarehq-ansible/pull/1019 and https://github.com/dimagi/commcare-hq/pull/18473 are deployed.

@emord 