### PR TITLE
Tweak postgres log retention on enikshay

### DIFF
--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -9,6 +9,7 @@ postgresql_config_home: "/etc/postgresql/{{ postgresql_version }}/main"
 postgresql_pid_file: "{{ postgresql_dir_path }}/{{ postgresql_version }}-main.pid"
 postgres_install_dir: "/usr/lib/postgresql/{{ postgresql_version }}"
 postgresql_archive_dir: "{{ postgresql_dir_path }}/wal_archive"
+postgresql_num_logs_to_keep: 20
 
 pgbouncer_port: 6432
 pgbouncer_pid_file: "/var/run/postgresql/pgbouncer.pid"

--- a/ansible/roles/postgresql/templates/rotate_logs.sh.j2
+++ b/ansible/roles/postgresql/templates/rotate_logs.sh.j2
@@ -1,6 +1,14 @@
 #!/bin/bash
 # keep latest 20 log files 
-find {{ postgresql_home }}/pg_log -type f -name '*.csv' -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -20 | cut -d $'\t' -f 2- | xargs --no-run-if-empty -d '\n' rm --
+find {{ postgresql_home }}/pg_log -type f -name '*.csv' -printf '%T@\t%p\n' \
+    | sort -t $'\t' -g \
+    | head -n -20 \
+    | cut -d $'\t' -f 2- \
+    | xargs --no-run-if-empty -d '\n' rm --
 
 # gzip all files except for the most recent 3
-find {{ postgresql_home }}/pg_log -type f -name '*.csv' -printf '%T@\t%p\n' | sort -t $'\t' -g | head -n -3 | cut -d $'\t' -f 2- | xargs --no-run-if-empty -d '\n' gzip --
+find {{ postgresql_home }}/pg_log -type f -name '*.csv' -printf '%T@\t%p\n' \
+    | sort -t $'\t' -g \
+    | head -n -3 \
+    | cut -d $'\t' -f 2- \
+    | xargs --no-run-if-empty -d '\n' gzip --

--- a/ansible/roles/postgresql/templates/rotate_logs.sh.j2
+++ b/ansible/roles/postgresql/templates/rotate_logs.sh.j2
@@ -1,8 +1,8 @@
 #!/bin/bash
-# keep latest 20 log files 
+# keep latest {{ postgresql_num_logs_to_keep }} log files
 find {{ postgresql_home }}/pg_log -type f -name '*.csv' -printf '%T@\t%p\n' \
     | sort -t $'\t' -g \
-    | head -n -20 \
+    | head -n -{{ postgresql_num_logs_to_keep }} \
     | cut -d $'\t' -f 2- \
     | xargs --no-run-if-empty -d '\n' rm --
 

--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -84,6 +84,7 @@ nofile_limit: 65536
 
 postgres_users: "{{ secrets.POSTGRES_USERS }}"
 
+postgresql_num_logs_to_keep: 100
 postgresql_shared_buffers: '10GB'
 postgresql_max_stack_depth: '6MB'
 postgresql_effective_cache_size: '32GB'


### PR DESCRIPTION
100 log files = 10GB. This is temporary while analyzing and tuning performance. The previous setting retained less than 8 hours of logs at peak usage times.

Review commits individually 🐠 

@emord cc @calellowitz @javierwilson @snopoke 