### PR TITLE
Commcare cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ DimagiKeyStore
 .idea/
 .DS_Store
 ansible/*.retry
+*.pyc
+*.egg-info

--- a/commcare-cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import print_function
 import getpass
+import os
 from six.moves import input
 from argparse import ArgumentParser
 import subprocess
@@ -21,15 +22,15 @@ class AnsiblePlaybook(object):
         def anisible_playbook(environment, vault_password, *cmd_args):
             cmd = (
                 'ansible-playbook',
-                '-u', '~/.commcare-cloud/ansible',
-                '-i', '~/.commcare-cloud/inventory/{env}'.format(env=environment),
-                '-e', '"@~/.commcare-cloud/vars/{env}/{env}_vault.yml"'.format(env=environment),
-                '-e', '"@~/.commcare-cloud/vars/{env}/{env}_public.yml"'.format(env=environment),
-                '--ask-vault-pass',
+                '-u', os.path.expanduser('~/.commcare-cloud/ansible'),
+                '-i', os.path.expanduser('~/.commcare-cloud/inventory/{env}'.format(env=environment)),
+                '-e', '"@{}"'.format(os.path.expanduser('~/.commcare-cloud/vars/{env}/{env}_vault.yml'.format(env=environment))),
+                '-e', '"@{}'.format(os.path.expanduser('~/.commcare-cloud/vars/{env}/{env}_public.yml"'.format(env=environment))),
+                '--vault-password-file=/bin/cat',
                 '--diff',
             ) + cmd_args
             print(' '.join(cmd))
-            p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+            p = subprocess.Popen(' '.join(cmd), stdin=subprocess.PIPE, shell=True)
             p.communicate(input='{}\n'.format(vault_password))
             return p.returncode
 

--- a/commcare-cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud.py
@@ -79,6 +79,19 @@ class AnsiblePlaybook(object):
         exit(exit_code)
 
 
+class UpdateConfig(object):
+    @staticmethod
+    def make_parser(parser):
+        parser.add_argument('--skip-check', action='store_true', default=False)
+        parser.add_argument('--branch', default='master')
+
+    @staticmethod
+    def run(args, unknown_args):
+        args.playbook = 'deploy_localsettings.yml'
+        unknown_args += ('--tags=localsettings',)
+        AnsiblePlaybook.run(args, unknown_args)
+
+
 def git_branch():
     return subprocess.check_output("git branch | grep '^*' | cut -d' ' -f2", shell=True,
                                    cwd=os.path.expanduser('~/.commcare-cloud/ansible')).strip()
@@ -100,10 +113,13 @@ def main():
     subparsers = parser.add_subparsers(dest='command')
 
     AnsiblePlaybook.make_parser(subparsers.add_parser('ansible-playbook'))
+    UpdateConfig.make_parser(subparsers.add_parser('update-config'))
 
     args, unknown_args = parser.parse_known_args()
     if args.command == 'ansible-playbook':
         AnsiblePlaybook.run(args, unknown_args)
+    if args.command == 'update-config':
+        UpdateConfig.run(args, unknown_args)
 
 if __name__ == '__main__':
     main()

--- a/commcare-cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud.py
@@ -23,7 +23,7 @@ class AnsiblePlaybook(object):
     def run(args, unknown_args):
         check_branch(args)
 
-        def anisible_playbook(environment, playbook, vault_password, *cmd_args):
+        def ansible_playbook(environment, playbook, vault_password, *cmd_args):
             cmd = (
                 'ANSIBLE_CONFIG={}'.format(os.path.expanduser('~/.commcare-cloud/ansible/ansible.cfg')),
                 'ansible-playbook',
@@ -41,10 +41,10 @@ class AnsiblePlaybook(object):
             return p.returncode
 
         def run_check():
-            return anisible_playbook(args.environment, args.playbook, get_ansible_vault_password(), '--check', *unknown_args)
+            return ansible_playbook(args.environment, args.playbook, get_ansible_vault_password(), '--check', *unknown_args)
 
         def run_apply():
-            return anisible_playbook(args.environment, args.playbook, get_ansible_vault_password(), *unknown_args)
+            return ansible_playbook(args.environment, args.playbook, get_ansible_vault_password(), *unknown_args)
 
         def get_ansible_vault_password():
             if not get_ansible_vault_password.value:

--- a/commcare-cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud.py
@@ -22,7 +22,7 @@ class AnsiblePlaybook(object):
         def anisible_playbook(environment, vault_password, *cmd_args):
             cmd = (
                 'ansible-playbook',
-                '-u', os.path.expanduser('~/.commcare-cloud/ansible'),
+                '-u', 'ansible',
                 '-i', os.path.expanduser('~/.commcare-cloud/inventory/{env}'.format(env=environment)),
                 '-e', '"@{}"'.format(os.path.expanduser('~/.commcare-cloud/vars/{env}/{env}_vault.yml'.format(env=environment))),
                 '-e', '"@{}'.format(os.path.expanduser('~/.commcare-cloud/vars/{env}/{env}_public.yml"'.format(env=environment))),

--- a/commcare-cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+from __future__ import print_function
+import getpass
+from six.moves import input
+from argparse import ArgumentParser
+import subprocess
+from clint.textui import puts, colored
+
+
+def ask(message):
+    return 'y' == input('{} [y/N]'.format(message))
+
+
+class AnsiblePlaybook(object):
+    @staticmethod
+    def make_parser(parser):
+        parser.add_argument('--skip-check', action='store_true', default=False)
+
+    @staticmethod
+    def run(args, unknown_args):
+        def anisible_playbook(environment, vault_password, *cmd_args):
+            cmd = (
+                'ansible-playbook',
+                '-u', '~/.commcare-cloud/ansible',
+                '-i', '~/.commcare-cloud/inventory/{env}'.format(env=environment),
+                '-e', '"@~/.commcare-cloud/vars/{env}/{env}_vault.yml"'.format(env=environment),
+                '-e', '"@~/.commcare-cloud/vars/{env}/{env}_public.yml"'.format(env=environment),
+                '--ask-vault-pass',
+                '--diff',
+            ) + cmd_args
+            print(' '.join(cmd))
+            p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+            p.communicate(input='{}\n'.format(vault_password))
+            return p.returncode
+
+        def run_check():
+            return anisible_playbook(args.environment, get_ansible_vault_password(), '--check', *unknown_args)
+
+        def run_apply():
+            return anisible_playbook(args.environment, get_ansible_vault_password(), *unknown_args)
+
+        def get_ansible_vault_password():
+            if not get_ansible_vault_password.value:
+                get_ansible_vault_password.value = getpass.getpass("Vault Password: ")
+            return get_ansible_vault_password.value
+        get_ansible_vault_password.value = None
+
+        exit_code = 0
+
+        if args.skip_check:
+            user_wants_to_apply = ask('Do you want to apply without running the check first?')
+        else:
+            exit_code = run_check()
+            if exit_code == 1:
+                # this means there was an error before ansible was able to start running
+                exit(exit_code)
+                return  # for IDE
+            elif exit_code == 0:
+                puts(colored.green(u"✓ Check completed with status code {}".format(exit_code)))
+                user_wants_to_apply = ask('Do you want to apply these changes?')
+            else:
+                puts(colored.red(u"✗ Check failed with status code {}".format(exit_code)))
+                user_wants_to_apply = ask('Do you want to try to apply these changes anyway?')
+
+        if user_wants_to_apply:
+            exit_code = run_apply()
+            if exit_code == 0:
+                puts(colored.green(u"✓ Apply completed with status code {}".format(exit_code)))
+            else:
+                puts(colored.red(u"✗ Apply failed with status code {}".format(exit_code)))
+
+        exit(exit_code)
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('environment')
+    subparsers = parser.add_subparsers(dest='command')
+
+    AnsiblePlaybook.make_parser(subparsers.add_parser('ansible-playbook'))
+
+    args, unknown_args = parser.parse_known_args()
+    print(args, unknown_args)
+    if args.command == 'ansible-playbook':
+        AnsiblePlaybook.run(args, unknown_args)
+
+if __name__ == '__main__':
+    main()

--- a/commcare-cloud/setup.py
+++ b/commcare-cloud/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='commcare-cloud',
+    description="A tool for managing commcare deploys.",
+    long_description="",
+    license='BSD-3',
+    packages=find_packages('.'),
+    entry_points={
+        'console_scripts': ['commcare-cloud = commcare_cloud:main'],
+    },
+    install_requires=(
+        'six',
+        'clint'
+    ),
+)

--- a/control/init.sh
+++ b/control/init.sh
@@ -39,10 +39,10 @@ pip install -e ~/commcarehq-ansible/commcare-cloud
 
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcarehq-ansible/control/init.sh ~/init-ansible
-[ ! -f ~/.commcare-cloud ] && mkdir ~/.commcare-cloud
-[ ! -f ~/.commcare-cloud/ansible ] && ln -s ~/commcarehq-ansible/ansible ~/.commcare-cloud/
-[ ! -f ~/.commcare-cloud/vars ] && ln -s ~/commcarehq-ansible/ansible/vars ~/.commcare-cloud/
-[ ! -f ~/.commcare-cloud/inventory ] && ln -s ~/commcare-hq-deploy/fab/inventory ~/.commcare-cloud/
+[ ! -d ~/.commcare-cloud ] && mkdir ~/.commcare-cloud
+[ ! -d ~/.commcare-cloud/ansible ] && ln -s ~/commcarehq-ansible/ansible ~/.commcare-cloud/
+[ ! -d ~/.commcare-cloud/vars ] && ln -s ~/commcarehq-ansible/ansible/vars ~/.commcare-cloud/
+[ ! -d ~/.commcare-cloud/inventory ] && ln -s ~/commcare-hq-deploy/fab/inventory ~/.commcare-cloud/
 
 alias ap='ansible-playbook -u ansible -i ../../commcare-hq-deploy/fab/inventory/$ENV -e "@vars/$ENV/${ENV}_vault.yml" -e "@vars/$ENV/${ENV}_public.yml" --ask-vault-pass'
 alias aps='ap deploy_stack.yml'

--- a/control/init.sh
+++ b/control/init.sh
@@ -40,6 +40,7 @@ pip install -e ~/commcarehq-ansible/commcare-cloud
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcarehq-ansible/control/init.sh ~/init-ansible
 [ ! -d ~/.commcare-cloud ] && mkdir ~/.commcare-cloud
+[ ! -d ~/.commcare-cloud/ansible ] && ln -s ~/commcarehq-ansible/ansible ~/.commcare-cloud/
 [ ! -d ~/.commcare-cloud/vars ] && ln -s ~/commcarehq-ansible/ansible/vars ~/.commcare-cloud/
 [ ! -d ~/.commcare-cloud/inventory ] && ln -s ~/commcare-hq-deploy/fab/inventory ~/.commcare-cloud/
 

--- a/control/init.sh
+++ b/control/init.sh
@@ -12,7 +12,6 @@ source virtualenvwrapper.sh
 if [ ! -d ~/.virtualenvs/ansible ]; then
     echo "Creating ansible virtualenv..."
     mkvirtualenv ansible
-    pip install -r ~/commcarehq-ansible/ansible/requirements.txt
 else
     workon ansible
 fi
@@ -35,8 +34,15 @@ echo "Downloading dependencies from galaxy"
 export ANSIBLE_ROLES_PATH=~/.ansible/roles
 ansible-galaxy install -r ~/commcarehq-ansible/ansible/requirements.yml
 
+pip install -r ~/commcarehq-ansible/ansible/requirements.txt
+pip install -e ~/commcarehq-ansible/ansible/commcare-cloud
+
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcarehq-ansible/control/init.sh ~/init-ansible
+[ ! -f ~/.commcare-cloud ] && mkdir ~/.commcare-cloud
+[ ! -f ~/.commcare-cloud/ansible ] && ln -s ~/commcarehq-ansible/ansible ~/.commcare-cloud/
+[ ! -f ~/.commcare-cloud/vars ] && ln -s ~/commcarehq-ansible/ansible/vars ~/.commcare-cloud/
+[ ! -f ~/.commcare-cloud/inventory ] && ln -s ~/commcare-hq-deploy/fab/inventory ~/.commcare-cloud/
 
 alias ap='ansible-playbook -u ansible -i ../../commcare-hq-deploy/fab/inventory/$ENV -e "@vars/$ENV/${ENV}_vault.yml" -e "@vars/$ENV/${ENV}_public.yml" --ask-vault-pass'
 alias aps='ap deploy_stack.yml'

--- a/control/init.sh
+++ b/control/init.sh
@@ -35,7 +35,7 @@ export ANSIBLE_ROLES_PATH=~/.ansible/roles
 ansible-galaxy install -r ~/commcarehq-ansible/ansible/requirements.yml
 
 pip install -r ~/commcarehq-ansible/ansible/requirements.txt
-pip install -e ~/commcarehq-ansible/ansible/commcare-cloud
+pip install -e ~/commcarehq-ansible/commcare-cloud
 
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcarehq-ansible/control/init.sh ~/init-ansible

--- a/control/init.sh
+++ b/control/init.sh
@@ -40,7 +40,6 @@ pip install -e ~/commcarehq-ansible/commcare-cloud
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcarehq-ansible/control/init.sh ~/init-ansible
 [ ! -d ~/.commcare-cloud ] && mkdir ~/.commcare-cloud
-[ ! -d ~/.commcare-cloud/ansible ] && ln -s ~/commcarehq-ansible/ansible ~/.commcare-cloud/
 [ ! -d ~/.commcare-cloud/vars ] && ln -s ~/commcarehq-ansible/ansible/vars ~/.commcare-cloud/
 [ ! -d ~/.commcare-cloud/inventory ] && ln -s ~/commcare-hq-deploy/fab/inventory ~/.commcare-cloud/
 


### PR DESCRIPTION
This adds a `commcare-cloud` CLI tool, which currently has one command, `ansible-playbook`. To usage is essentially

```
commcare-cloud <env> ansible-playbook <...>
```

e.g.

```
commcare-cloud staging ansible-playbook deploy_localsettings.yml --tags=localsettings
```

The default behavior is to run with `--check` (`--diff` is always on), tell you whether it succeeded, and then prompt you whether to abort (default) or apply it. You can also run it with `--skip-check` to skip the check portion (in which case it will still ask you to confirm.

Other nice features:
- you only have to enter the vault password once per run and it'll use it for both check and apply.
- if you are not on master, it will fail, and tell you what cli arg to add to make it not fail.
- there's an additional shortcut for what we've been calling "localsettings" but I'm calling config as per https://12factor.net/config: `commcare-cloud staging update-config` is equivalent to `commcare-cloud staging ansible-playbook deploy_localsettings.yml --tags=localsettings`
- ⭐️ it installs itself, so once this is merged the install path is
  - log in
  - `update-code`
  - run `. init-ansible` if you can remember that, or else just log out and log in
  ...and you're ready to go.