### PR TITLE
add commcarehq-ansible/config if it doesn't exist

### DIFF
--- a/control/update_code.sh
+++ b/control/update_code.sh
@@ -32,6 +32,7 @@ function update_repo() {
     git submodule update --init --recursive
 }
 
+[ ! -d 'commcarehq-ansible/config' ] && mkdir commcarehq-ansible/config
 for repo in "commcare-hq-deploy" "commcarehq-ansible/config" "commcarehq-ansible"
 do
     cd ~/$repo


### PR DESCRIPTION
so that the init script doesn't error on new machines (even if it is
harmless, it's annoying)

A better long term fix is to move the few remaining things from config/
into the ansible vault files