### PR TITLE
make bash completion run in other envs

### DIFF
--- a/control/.bash_completion
+++ b/control/.bash_completion
@@ -2,7 +2,7 @@ _commcare_cloud()
 {
     local cur prev opts
     COMPREPLY=()
-    FILE_EXCHANGE_DIR=~/commcarehq-ansible/ansible
+    FILE_EXCHANGE_DIR=~/.commcare-cloud/ansible
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     opts="--help --version"


### PR DESCRIPTION
by respecting the ~/.commcare-cloud/ abstraction

@javierwilson found this when playing around with it locally