### PR TITLE
minorly simplify .bash_completion

### DIFF
--- a/control/.bash_completion
+++ b/control/.bash_completion
@@ -23,7 +23,7 @@ _commcare_cloud()
         fi
         ;;
     3)
-        IFS=$'\n' tmp=( $(compgen -W "$(ls $FILE_EXCHANGE_DIR)" -- "${COMP_WORDS[$COMP_CWORD]}" ))
+        IFS=$'\n' tmp=( $(compgen -W "$(ls $FILE_EXCHANGE_DIR)" -- ${cur}) )
         COMPREPLY=( "${tmp[@]// /\ }" )
         ;;
     esac


### PR DESCRIPTION
@javierwilson I don't know much about bash completion but when I was trying to debug locally, I noticed that this part looked the same as above (except for an extra `$` inside there) and figured that you had meant to replace this usage too. If not, feel free to close!

