### PR TITLE
Make enikshay pg work_mem more reasonable (and update default)

### DIFF
--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -19,7 +19,7 @@ pgbouncer_ini: "{{ pgbouncer_config_home }}/pgbouncer.ini"
 pgbouncer_users: "{{ pgbouncer_config_home }}/userlist.txt"
 
 postgresql_max_connections: 20
-postgresql_work_mem: '1MB'
+postgresql_work_mem: '8MB'
 postgresql_shared_buffers: '1024MB'
 postgresql_max_stack_depth: '2MB'
 postgresql_effective_cache_size: '128MB'

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -81,7 +81,7 @@ log_connections = on
 log_disconnections = on
 log_line_prefix = '%t '
 log_lock_waits = on
-log_temp_files = -1
+log_temp_files = 0
 
 
 # RUNTIME STATISTICS

--- a/ansible/vars/enikshay/enikshay_public.yml
+++ b/ansible/vars/enikshay/enikshay_public.yml
@@ -94,6 +94,7 @@ postgresql_num_logs_to_keep: 100
 postgresql_shared_buffers: '10GB'
 postgresql_max_stack_depth: '6MB'
 postgresql_effective_cache_size: '32GB'
+postgresql_work_mem: '16MB'
 postgresql_max_connections: 600
 postgresql_checkpoint_segments: 32
 pgbouncer_max_connections: 1600


### PR DESCRIPTION
The current very low `work_mem` setting on enikshay is a likely cause of lots of disk access and inefficient query plans.

Numerous sources recommend at least 16MB, including http://pgtune.leopard.in.ua/ (when combined with other parameters from the enikshay server). Some sources say if you can't set `work_mem` to 16MB or more you need more RAM.

Note: I'm offline all next week, so unless you want to oversee this rollout, let's wait to merge until I'm back. Although feel free to roll it out before I'm back if you want to.

@snopoke @javierwilson 