### PR TITLE
create hashlib extension on all DBs

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -269,7 +269,6 @@
   postgresql_ext:
     name: hashlib
     db: "{{item.name}}"
-  when: (item.get('django_alias') == 'proxy' and item.get('host', localsettings.PG_DATABASE_HOST) == inventory_hostname) or is_monolith|bool
   with_items: "{{ postgresql_dbs }}"
 
 - name: Make plproxy a trusted language


### PR DESCRIPTION
This will be necessary to get https://github.com/dimagi/commcare-hq/pull/18611/ working.

[[This stack overflow post](https://stackoverflow.com/questions/7014437/error-permission-denied-for-language-c)] summarizes the problem and solutions. Basically the problem is that you need “superuser” privileges to create this extension but the migrations are run under `hqweb...` which does not have it. The solutions are:

- Make c a trusted language using a superuser (not recommend)
- Run the command as a superuser instead
- (Temporarily) provide superuser credentials to the running user

Of these options it seems that just doing it as a superuser from ansible during setup makes the most logical sense since the others would still have to involve the postgres user (and likely ansible) and either have security downsides or be more complex to roll out.

Note: I haven't tested this yet though it seems on the safe end in terms of the changes it is making. Working on getting my ansible environment back online...