### PR TITLE
Apache no longer serves kafka 0.8.2.2 here

### DIFF
--- a/ansible/roles/kafka/defaults/main.yml
+++ b/ansible/roles/kafka/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-apache_mirror: apache.mirror.anlx.net
+apache_mirror: archive.apache.org/dist
 kafka_version: 0.8.2.2
 kafka_user: kafka
 kafka_group: kafka


### PR DESCRIPTION
0.10 is the oldest available on apache.mirror.anlx.net. Switching to the archive site works for me. Alternatives to my proposed change include:
- changing the Kafka version
- setting the mirror above to `archive.apache.org` and adding the `/dist` to https://github.com/dimagi/commcarehq-ansible/blob/master/ansible/roles/kafka/tasks/main.yml#L16

I went with this single change because it was easier to PR from github—no offence taken if you implement one of the other methods above!