### PR TITLE
add zone to nginx upstream config

### DIFF
--- a/ansible/roles/nginx/templates/site.j2
+++ b/ansible/roles/nginx/templates/site.j2
@@ -4,6 +4,8 @@
 
 {% for balancer in item.server.get('balancers', []) %}
 upstream {{ balancer.name }} {
+  zone {{ balancer.name }} {{ balancer.zone|default('64k') }};
+
   {% if balancer.get('method') %}
   {{ balancer.method }};
   {% else %}


### PR DESCRIPTION
"If the upstream directive does not include the zone directive, each worker process keeps its own copy of the server group configuration and maintains its own set of related counters. The counters include the current number of connections to each server in the group and the number of failed attempts to pass a request to a server. As a result, the server group configuration isn’t changeable.

If the upstream directive does include the zone directive, the configuration of the server group is placed in a memory area shared among all worker processes. This scenario is dynamically configurable, because the worker processes access the same copy of the group configuration and utilize the same related counters.

The zone directive is mandatory for health checks and on-the-fly reconfiguration of the server group. However, other features of the server groups can benefit from the use of this directive as well."
https://www.nginx.com/resources/admin-guide/load-balancer/