### PR TITLE
allows (optional) replication delay

### DIFF
--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -53,6 +53,10 @@ wal_keep_segments = 8
 hot_standby = on    # ignored on masters
 max_replication_slots = 8
 
+{% if is_pg_standby|default(false) and postgresql_max_standby_delay|default(false) %}
+max_standby_archive_delay = {{ postgresql_max_standby_delay }}
+max_standby_streaming_delay = {{ postgresql_max_standby_delay }}
+{% endif %}
 
 # QUERY TUNING
 

--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -116,8 +116,8 @@ postgres_users:
       role_attr_flags: 'LOGIN,REPLICATION'
 
 pg_replication_slots:
- 192.168.33.16:
-   - standby1
+  192.168.33.16:
+    - standby1
 
 encrypted_root: '/opt/data'
 postgresql_log_directory: "{{ encrypted_root }}/pg_log"
@@ -127,6 +127,7 @@ postgresql_work_mem: '8MB'
 postgresql_shared_buffers: '128MB'
 postgresql_max_stack_depth: '6MB'
 postgresql_effective_cache_size: '4GB'
+postgresql_max_standby_delay: '-1'
 pgbouncer_max_connections: 100
 pgbouncer_default_pool: 15
 pgbouncer_reserve_pool: 4

--- a/ansible/vars/icds/icds_public.yml
+++ b/ansible/vars/icds/icds_public.yml
@@ -74,6 +74,7 @@ postgres_users: "{{ secrets.POSTGRES_USERS }}"
 postgresql_shared_buffers: '8GB'
 postgresql_max_stack_depth: '6MB'
 postgresql_effective_cache_size: '16GB'
+postgresql_max_standby_delay: '-1'
 pgbouncer_reserve_pool: 5
 pgbouncer_pool_timeout: 1
 pgbouncer_pool_mode: transaction


### PR DESCRIPTION
see https://www.postgresql.org/docs/9.4/static/runtime-config-replication.html
this is needed when using pg_dump from  the standby