### PR TITLE
Remove unused MOTECH servers

### DIFF
--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -20,12 +20,6 @@ nginx_sites:
      - name: /supply-dhis
        proxy_pass: http://motech-main.internal.commcarehq.org:8888/supply-dhis
        proxy_read_timeout: 360s
-     - name: /cdc-moz
-       proxy_pass: http://motech3.internal-va.commcarehq.org:8080/cdc-moz
-       proxy_read_timeout: 360s
-     - name: /pi-lad
-       proxy_pass: http://motech4.internal-va.commcarehq.org:8080/pi-lad
-       proxy_read_timeout: 360s
      - name: /endos
        proxy_pass: http://motech1.internal.commcarehq.org:8080/endos
        proxy_read_timeout: 360s

--- a/ansible/roles/nginx/vars/motech.yml
+++ b/ansible/roles/nginx/vars/motech.yml
@@ -20,9 +20,6 @@ nginx_sites:
      - name: /supply-dhis
        proxy_pass: http://motech-main.internal.commcarehq.org:8888/supply-dhis
        proxy_read_timeout: 360s
-     - name: /endos
-       proxy_pass: http://motech1.internal.commcarehq.org:8080/endos
-       proxy_read_timeout: 360s
      - name: /endos-dhis
        proxy_pass: http://motech1.internal.commcarehq.org:8080/endos-dhis
        proxy_read_timeout: 360s


### PR DESCRIPTION
Once this is deployed, I can actually pull down the servers from Rackspace.

@calellowitz @mkangia  (since you're on interrupt). 