### PR TITLE
Fix find expression in log rotation script

### DIFF
--- a/ansible/roles/postgresql/templates/rotate_logs.sh.j2
+++ b/ansible/roles/postgresql/templates/rotate_logs.sh.j2
@@ -1,6 +1,9 @@
 #!/bin/bash
 # keep latest {{ postgresql_num_logs_to_keep }} log files
-find {{ postgresql_log_directory }} -type f -name '*.csv' -printf '%T@\t%p\n' \
+find {{ postgresql_log_directory }} \
+    -type f \
+    \( -name '*.csv' -o -name '*.csv.gz' -o -name '*.log' \) \
+    -printf '%T@\t%p\n' \
     | sort -t $'\t' -g \
     | head -n -{{ postgresql_num_logs_to_keep }} \
     | cut -d $'\t' -f 2- \


### PR DESCRIPTION
Was missing .csv.gz and .log files, which means old log files were not being deleted at all because all but the most recent 3 end with .gz

This is too complicated...

@emord cc @javierwilson @snopoke @calellowitz 