### PR TITLE
Fix shared directory variables.

### DIFF
--- a/ansible/roles/shared_dir.yml
+++ b/ansible/roles/shared_dir.yml
@@ -4,6 +4,7 @@
   hosts: shared_dir_host  # Should be one
   become: yes
   vars_files:
+    - ../group_vars/all.yml
     - shared_dir/vars/main.yml
   tasks:
     - include: shared_dir/tasks/install.yml
@@ -13,6 +14,7 @@
   hosts: webworkers:proxy:celery:pillowtop:shared_dir_host
   become: yes
   vars_files:
+    - ../group_vars/all.yml
     - shared_dir/vars/main.yml
   tasks:
     - include: shared_dir/tasks/install.yml


### PR DESCRIPTION
@calellowitz @snopoke 

Looks like this is because we specify the vars file for share directory. before ansible 2.1.1.0 it also loaded group vars from the current working directory which was a "bug" (disagreement here: https://github.com/ansible/ansible/issues/16878)