### PR TITLE
control monit state

### DIFF
--- a/ansible/roles/monit/tasks/main.yml
+++ b/ansible/roles/monit/tasks/main.yml
@@ -14,5 +14,5 @@
 
 - name: start monit
   become: yes
-  service: name="monit" state=started enabled=yes
+  service: name="monit" state={{ monit_state|default("started") }} enabled=yes
   tags: monit

--- a/ansible/vars/icds-new/icds-new_public.yml
+++ b/ansible/vars/icds-new/icds-new_public.yml
@@ -5,6 +5,7 @@ deploy_env: icds
 env_name: icds-new
 internal_domain_name: 'internal-icds.commcarehq.org'
 cluster_ip_range: '10.247.164.0/23'
+monit_state: 'stopped'
 
 # is tableau necessary? tableau_server: 10.247.24.11:80
 daily_deploy_email: tech-announce-daily@dimagi.com


### PR DESCRIPTION
this will work if run with deploy_common.  it may not work if run with deploy_stack since later the cuch role will reload monit, and reload starts a service if stopped, or so i've read.