### PR TITLE
 set secure proxy ssl header setting

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -252,6 +252,7 @@ SEND_BROKEN_LINK_EMAILS = True
 
 OVERRIDE_LOCATION = "https://www.commcarehq.org"
 DEFAULT_PROTOCOL = "https"
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
 
 ANALYTICS_IDS = {
     'GOOGLE_ANALYTICS_API_ID': '{{ localsettings.GOOGLE_ANALYTICS_API_ID|default('', true) }}',

--- a/ansible/roles/nginx/vars/cas_ssl.yml
+++ b/ansible/roles/nginx/vars/cas_ssl.yml
@@ -45,6 +45,7 @@ nginx_sites:
    proxy_set_headers:
    - "Host $host"
    - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Protocol  $scheme"
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:

--- a/ansible/roles/nginx/vars/cchq_http.yml
+++ b/ansible/roles/nginx/vars/cchq_http.yml
@@ -8,6 +8,7 @@ nginx_sites:
    client_max_body_size: 100m
    proxy_set_headers:
    - "Host $host"
+   - "X-Forwarded-Protocol  $scheme"
    locations:
      - name: /
        return: "301 https://$server_name$request_uri"

--- a/ansible/roles/nginx/vars/cchq_http.yml
+++ b/ansible/roles/nginx/vars/cchq_http.yml
@@ -6,7 +6,8 @@ nginx_sites:
    listen: "80"
    server_name: "{{ SITE_HOST }}"
    client_max_body_size: 100m
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://$server_name$request_uri"

--- a/ansible/roles/nginx/vars/cchq_http_j2me.yml
+++ b/ansible/roles/nginx/vars/cchq_http_j2me.yml
@@ -12,6 +12,7 @@ nginx_sites:
     proxy_set_headers:
     - "Host $host"
     - "X-Forwarded-For $remote_addr"
+    - "X-Forwarded-Protocol  $scheme"
     add_header: "X-Frame-Options SAMEORIGIN"
     access_log: "{{ log_home }}/{{ deploy_env }}-j2me-timing.log timing"
     locations:

--- a/ansible/roles/nginx/vars/cchq_http_redirect.yml
+++ b/ansible/roles/nginx/vars/cchq_http_redirect.yml
@@ -6,7 +6,8 @@ nginx_sites:
    listen: "80"
    server_name: "{{ NO_WWW_SITE_HOST }}"
    client_max_body_size: 100m
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 http://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/cchq_http_redirect.yml
+++ b/ansible/roles/nginx/vars/cchq_http_redirect.yml
@@ -8,6 +8,7 @@ nginx_sites:
    client_max_body_size: 100m
    proxy_set_headers:
    - "Host $host"
+   - "X-Forwarded-Protocol  $scheme"
    locations:
      - name: /
        return: "301 http://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/cchq_redirect.yml
+++ b/ansible/roles/nginx/vars/cchq_redirect.yml
@@ -8,6 +8,7 @@ nginx_sites:
    client_max_body_size: 100m
    proxy_set_headers:
    - "Host $host"
+   - "X-Forwarded-Protocol  $scheme"
    locations:
      - name: /
        return: "301 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/cchq_redirect.yml
+++ b/ansible/roles/nginx/vars/cchq_redirect.yml
@@ -6,7 +6,8 @@ nginx_sites:
    listen: "443 ssl"
    server_name: "{{ NO_WWW_SITE_HOST }}"
    client_max_body_size: 100m
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/cchq_ssl.yml
+++ b/ansible/roles/nginx/vars/cchq_ssl.yml
@@ -17,6 +17,7 @@ nginx_sites:
    proxy_set_headers:
    - "Host $host"
    - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Protocol  $scheme"
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:

--- a/ansible/roles/nginx/vars/commtrack_http.yml
+++ b/ansible/roles/nginx/vars/commtrack_http.yml
@@ -5,7 +5,8 @@ nginx_sites:
    listen: "80"
    server_name: "{{ COMMTRACK_SITE_HOST }}"
    client_max_body_size: 100m
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/commtrack_http.yml
+++ b/ansible/roles/nginx/vars/commtrack_http.yml
@@ -7,6 +7,7 @@ nginx_sites:
    client_max_body_size: 100m
    proxy_set_headers:
    - "Host $host"
+   - "X-Forwarded-Protocol  $scheme"
    locations:
      - name: /
        return: "301 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/commtrack_ssl.yml
+++ b/ansible/roles/nginx/vars/commtrack_ssl.yml
@@ -10,6 +10,7 @@ nginx_sites:
    client_max_body_size: 100m
    proxy_set_headers:
    - "Host $host"
+   - "X-Forwarded-Protocol  $scheme"
    locations:
      - name: /
        return: "301 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/commtrack_ssl.yml
+++ b/ansible/roles/nginx/vars/commtrack_ssl.yml
@@ -8,7 +8,8 @@ nginx_sites:
    listen: "443 ssl"
    server_name: "{{ COMMTRACK_SITE_HOST }} www.{{ COMMTRACK_SITE_HOST }}"
    client_max_body_size: 100m
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://{{ SITE_HOST }}$request_uri"

--- a/ansible/roles/nginx/vars/enikshay_ssl.yml
+++ b/ansible/roles/nginx/vars/enikshay_ssl.yml
@@ -19,6 +19,7 @@ nginx_sites:
    proxy_set_headers:
    - "Host $host"
    - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Protocol  $scheme"
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:

--- a/ansible/roles/nginx/vars/icds_tableau_http.yml
+++ b/ansible/roles/nginx/vars/icds_tableau_http.yml
@@ -5,7 +5,8 @@ nginx_sites:
    file_name: "icds_tableau_http"
    listen: "80"
    server_name: "{{ TABLEAU_HOST }}"
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://$server_name"

--- a/ansible/roles/nginx/vars/motech2_http.yml
+++ b/ansible/roles/nginx/vars/motech2_http.yml
@@ -5,7 +5,8 @@ nginx_sites:
    file_name: "motech2_http"
    listen: "80"
    server_name: "test-supply-motech.commcarehq.org"
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://$server_name$request_uri"

--- a/ansible/roles/nginx/vars/motech_http.yml
+++ b/ansible/roles/nginx/vars/motech_http.yml
@@ -5,7 +5,8 @@ nginx_sites:
    file_name: "motech_http"
    listen: "80"
    server_name: "motech.commcarehq.org"
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://$server_name$request_uri"

--- a/ansible/roles/nginx/vars/pna_ssl.yml
+++ b/ansible/roles/nginx/vars/pna_ssl.yml
@@ -19,6 +19,7 @@ nginx_sites:
    proxy_set_headers:
    - "Host $host"
    - "X-Forwarded-For $remote_addr"
+   - "X-Forwarded-Protocol  $scheme"
    add_header: "X-Frame-Options SAMEORIGIN"
    access_log: "{{ log_home }}/{{ deploy_env }}-timing.log timing"
    locations:

--- a/ansible/roles/nginx/vars/wiki.yml
+++ b/ansible/roles/nginx/vars/wiki.yml
@@ -4,7 +4,8 @@ nginx_sites:
    file_name: wiki
    listen: "443 ssl"
    server_name: "wiki.commcarehq.org help.commcarehq.org"
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        proxy_pass: https://confluence.internal.dimagi.com

--- a/ansible/roles/nginx/vars/wiki_http.yml
+++ b/ansible/roles/nginx/vars/wiki_http.yml
@@ -5,7 +5,8 @@ nginx_sites:
    file_name: "wiki_http"
    listen: "80"
    server_name: "wiki.commcarehq.org help.commcarehq.org"
-   proxy_set_header: "Host $host"
+   proxy_set_headers:
+   - "Host $host"
    locations:
      - name: /
        return: "301 https://$server_name/display/commcarepublic/Home"


### PR DESCRIPTION
This allows Django to know whether a request is secure or not
https://docs.djangoproject.com/en/1.11/ref/settings/#secure-proxy-ssl-header

Without this `request.build_absolute_uri()` will use `http` as the request scheme instead of `https`. This is currently breaking dashboard feed URLs : https://manage.dimagi.com/default.asp?266533