### PR TITLE
removes formplayer cron tasks

### DIFF
--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -1,0 +1,7 @@
+---
+- name: Cleanup cron jobs
+  hosts:
+    - all:!formplayer
+  become: true
+  tasks:
+    - {include: 'roles/formplayer/tasks/cleanup.yml', tags: ['formplayer', 'cleanup']}

--- a/ansible/roles/formplayer/tasks/cleanup.yml
+++ b/ansible/roles/formplayer/tasks/cleanup.yml
@@ -1,0 +1,20 @@
+- name: Create purging cron jobs (cleanup)
+  become: yes
+  cron:
+    name: "{{ item.name }}"
+    special_time: daily
+    user: root
+    cron_file: purge_formplayer_files
+    state: absent
+  with_items:
+    - {name: 'Purge temp files' }
+    - {name: 'Purge sqlite db files' }
+  when: "'formplayer' not in group_names"
+
+- name: Create cron job to archive sqlite db files (cleanup)
+  become: yes
+  cron:
+    name: 'Archive sqlite db files'
+    user: '{{ cchq_user }}'
+    state: absent
+  when: "'formplayer' not in group_names"


### PR DESCRIPTION
i intend this to grow to cover all services, i'm starting with formplayer.
when we move services around, we have to cleanup cron jobs and other stuff (dbs probably best deleted manually?).