### PR TITLE
link config dir to ~/.commcare-cloud/

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -43,6 +43,7 @@ wait
 [ ! -d ~/.commcare-cloud/ansible ] && ln -s ~/commcarehq-ansible/ansible ~/.commcare-cloud/
 [ ! -d ~/.commcare-cloud/vars ] && ln -s ~/commcarehq-ansible/ansible/vars ~/.commcare-cloud/
 [ ! -d ~/.commcare-cloud/inventory ] && ln -s ~/commcare-hq-deploy/fab/inventory ~/.commcare-cloud/
+[ ! -d ~/.commcare-cloud/config ] && ln -s ~/commcarehq-ansible/config ~/.commcare-cloud/
 
 alias ap='ansible-playbook -u ansible -i ../../commcare-hq-deploy/fab/inventory/$ENV -e "@vars/$ENV/${ENV}_vault.yml" -e "@vars/$ENV/${ENV}_public.yml" --ask-vault-pass'
 alias aps='ap deploy_stack.yml'


### PR DESCRIPTION
@nickpell thanks for raising the issue, this should fix it.

Fixes the following error
```
commcare-cloud production ansible-playbook deploy_proxy.yml
....
TASK [nginx : Copy cchq SSL cert] **********************************************

fatal: [hqproxy0.internal-va.commcarehq.org]: FAILED! => {"changed": false, "failed": true, "msg": "could not find src=/home/npellegrino/.commcare-cloud/ansible/../config/production/ssl/commcarehq.org.combined.crt, Could not find or access '/home/npellegrino/.commcare-cloud/ansible/../config/production/ssl/commcarehq.org.combined.crt'"}
```

Solution was just to link `config` to the `~/.commcare-cloud/` dir.