### PR TITLE
pna: fixes nginx redirect loop

### DIFF
--- a/ansible/vars/pna/pna_public.yml
+++ b/ansible/vars/pna/pna_public.yml
@@ -6,7 +6,7 @@ deploy_env: pna
 
 active_sites:
   cchq_ssl: True
-  cchq_redirect: True
+  cchq_redirect: False
   cchq_http: True
   cchq_http_j2me: False
   cchq_http_redirect: False

--- a/ansible/vars/pna/pna_public.yml
+++ b/ansible/vars/pna/pna_public.yml
@@ -1,7 +1,6 @@
 SITE_HOST: 'commcare.pna.sn'
 PNA_SITE_HOST: 'pna.commcarehq.org'
 COMMTRACK_SITE_HOST: 'commcare.pna.sn'
-NO_WWW_SITE_HOST: 'commcare.pna.sn'
 deploy_env: pna
 
 active_sites:


### PR DESCRIPTION
gladly, this error was being ignored by nginx, due the a conflicting server_name.