### PR TITLE
stop spam from dev env

### DIFF
--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -199,6 +199,7 @@ postgresql_dbs:
 #    django_alias: ucr
 
 mailrelay: 'relay.example.com'
+root_email: 'root@example.com'
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"


### PR DESCRIPTION
root_email is used in /etc/aliases, sending all kind of alerts to the default dimagi.com email. this prevents it.