### PR TITLE
switch prod synclogdb

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -123,7 +123,7 @@ COUCH_DATABASES = {
 {% endfor %}
 }
 
-{% if localsettings.CUSTOM_SYNCLOGS_DB %}
+{% if 'CUSTOM_SYNCLOGS_DB' in localsettings %}
 CUSTOM_SYNCLOGS_DB = '{{ localsettings.CUSTOM_SYNCLOGS_DB }}'
 {% endif %}
 

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -123,6 +123,10 @@ COUCH_DATABASES = {
 {% endfor %}
 }
 
+{% if localsettings.CUSTOM_SYNCLOGS_DB %}
+CUSTOM_SYNCLOGS_DB = '{{ localsettings.CUSTOM_SYNCLOGS_DB }}'
+{% endif %}
+
 {% if 'BIGCOUCH' in localsettings %}
 BIGCOUCH = '{{ localsettings.BIGCOUCH }}'
 {% endif %}

--- a/ansible/vars/production/production_public.yml
+++ b/ansible/vars/production/production_public.yml
@@ -189,6 +189,7 @@ localsettings:
   COUCH_CACHE_VIEWS: True
   COUCH_MONITORING_USERNAME: "{{ localsettings_private.COUCH_MONITORING_USERNAME }}"
   COUCH_MONITORING_PASSWORD: "{{ localsettings_private.COUCH_MONITORING_PASSWORD }}"
+  CUSTOM_SYNCLOGS_DB: "synclogs_2017-11-01"
   DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
   DROPBOX_APP_NAME: 'CommCareHQFiles'
   DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"


### PR DESCRIPTION
New synclog DB is up to date so we're ready to make the switch:

![image](https://user-images.githubusercontent.com/249606/33714730-a9276fe8-db58-11e7-9a64-4e4a13ffebf9.png)

![image](https://user-images.githubusercontent.com/249606/33714743-b8b32006-db58-11e7-9aeb-e7f551262870.png)
