### PR TITLE
monit should be manually started (after-reboot)

### DIFF
--- a/ansible/roles/monit/tasks/main.yml
+++ b/ansible/roles/monit/tasks/main.yml
@@ -14,5 +14,7 @@
 
 - name: start monit
   become: yes
-  service: name="monit" state=started enabled=yes
-  tags: monit
+  service: name="monit" state=started enabled=no
+  tags:
+    - monit
+    - after-reboot


### PR DESCRIPTION
autostarting monit is crazy, since must services need to be started after "after-reboot" is ran (ecrypt mounted)