### PR TITLE
Allow migrations on icds-ucr for softlayer

### DIFF
--- a/ansible/vars/softlayer/softlayer_public.yml
+++ b/ansible/vars/softlayer/softlayer_public.yml
@@ -119,7 +119,6 @@ postgresql_dbs:
     django_alias: ucr
   - django_alias: icds-ucr
     name: icds-ucr
-    django_migrate: False
   - name: "{{ formplayer_db_name }}"
   - name: commcarehq_icds_testdata
 


### PR DESCRIPTION
This will match https://github.com/dimagi/commcarehq-ansible/blob/master/ansible/vars/icds/icds_public.yml#L144-L147

The dashboard tables are stored in the UCR database which has migrations and some QA happens on there

buddy @czue 