### PR TITLE
update set standby with progress

### DIFF
--- a/ansible/roles/postgresql/tasks/standby_progress.yml
+++ b/ansible/roles/postgresql/tasks/standby_progress.yml
@@ -1,0 +1,21 @@
+- name: Check sync status
+  async_status:
+    jid: "{{ async_results.ansible_job_id }}"
+  register: async_poll_results
+  when: not async_poll_results.get('finished', True)
+
+- name: get standby size
+  shell: du -s {{ postgresql_home }}
+  register: standby_size_output
+  when: not async_poll_results.get('finished', True)
+
+- debug:
+    msg:
+      - "Progress = {{ (100 * standby_size_output.stdout.split()[0]|int / master_size_output.stdout.split()[0]|int)|int }}%"
+      - "Master size: {{ master_size_output.stdout.split()[0]|int }}"
+      - "Standby size: {{ standby_size_output.stdout.split()[0]|int }}"
+  when: not async_poll_results.get('finished', True)
+
+- pause:
+    seconds: 300
+  when: not async_poll_results.get('finished', True)

--- a/ansible/setup_pg_standby.yml
+++ b/ansible/setup_pg_standby.yml
@@ -41,10 +41,18 @@
 - hosts:
     - "{{ standby }}"
   become: yes
-  become_user: postgres
   vars_files:
     - roles/postgresql/defaults/main.yml
   tasks:
+    - name: get master size
+      delegate_to: "{{ hot_standby_master }}"
+      shell: du -s {{ postgresql_home }}
+      register: master_size_output
+
+    - debug:
+        msg: "Master DB Size: {{ master_size_output.stdout.split()[0]|int }}"
+      when: not ansible_check_mode
+
     - name: execute base backup
       shell: |
         export PGPASSWORD="{{ postgres_users.replication.password }}" && \
@@ -53,6 +61,33 @@
           -U {{ postgres_users.replication.username }} \
           -D {{ postgresql_home }} \
           -P -v --xlog-method=stream 2>&1
+      async: 7200
+      poll: 0
+      register: async_results
+      when: not ansible_check_mode
+
+    - name: Check sync status
+      async_status:
+        jid: "{{ async_results.ansible_job_id }}"
+      register: async_poll_results
+      when: not ansible_check_mode
+
+    - name: create progress tasks
+      include_tasks: roles/postgresql/tasks/main/progress.yml
+      with_items: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
+      when: not ansible_check_mode
+
+    - name: Check sync status
+      async_status:
+        jid: "{{ async_results.ansible_job_id }}"
+      register: async_poll_results
+      until: async_poll_results.finished
+      retries: 100
+      delay: 300
+      when: not ansible_check_mode
+
+    - debug: var=async_poll_results
+      when: not ansible_check_mode
 
     - name: add new configuration "recovery.conf"
       blockinfile:
@@ -63,6 +98,13 @@
           primary_conninfo = 'user={{ postgres_users.replication.username }} password={{ postgres_users.replication.password }} host={{ hot_standby_master }} port={{ postgresql_port }} sslmode=prefer'
           primary_slot_name = '{{ replication_slot }}'
           recovery_target_timeline = 'latest'
+
+    - name: Reset ownership
+      file:
+        dest: "{{ postgresql_home }}"
+        state: directory
+        owner: postgres
+        group: postgres
 
 - hosts:
     - "{{ standby }}"

--- a/ansible/setup_pg_standby.yml
+++ b/ansible/setup_pg_standby.yml
@@ -73,7 +73,7 @@
       when: not ansible_check_mode
 
     - name: create progress tasks
-      include_tasks: roles/postgresql/tasks/main/progress.yml
+      include_tasks: roles/postgresql/tasks/progress.yml
       with_items: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
       when: not ansible_check_mode
 

--- a/ansible/setup_pg_standby.yml
+++ b/ansible/setup_pg_standby.yml
@@ -73,7 +73,7 @@
       when: not ansible_check_mode
 
     - name: create progress tasks
-      include_tasks: roles/postgresql/tasks/progress.yml
+      include_tasks: roles/postgresql/tasks/standby_progress.yml
       with_items: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
       when: not ansible_check_mode
 


### PR DESCRIPTION
This makes the pg basebackup run as an async task and then runs a loop of other tasks to compare the size of the standby node data with that of the master as a way of estimating progress