### PR TITLE
make setup_bidirectional_auth.yml not delete other keys

### DIFF
--- a/ansible/roles/setup_auth_keys.yml
+++ b/ansible/roles/setup_auth_keys.yml
@@ -24,7 +24,6 @@
     user: "{{username}}"
     state: "{{ state }}"
     key: "{{ lookup('file', '/tmp/id_rsa.tmp') }}"
-    exclusive: yes
   delegate_to: "{{ hostTo }}"
   ignore_errors: "{{ ansible_check_mode }}"
 


### PR DESCRIPTION
this was necessary for the icds couchdb2 migration because 3 machines are rsyncing from a single one.
also, when I ran this for user ansible, it deleted all of our personal keys, which was really annoying to get out of