### PR TITLE
change icds-new ES cluster name to icds-2.0

### DIFF
--- a/ansible/vars/icds-new/icds-new_public.yml
+++ b/ansible/vars/icds-new/icds-new_public.yml
@@ -53,7 +53,7 @@ ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 fake_ssl_cert: no
 
 elasticsearch_endpoint: '{{ groups.es0.0 }}'
-elasticsearch_cluster_name: 'prodhqes-1.x'
+elasticsearch_cluster_name: 'icds-2.0'
 
 formplayer_sentry_dsn: '{{ secrets.FORMPLAYER_SENTRY_DSN }}'
 


### PR DESCRIPTION
prodhqes-1.x is a holdover from the old cluster. The migration docs seemed to pretty clearly suggest we want the ES cluster on the new environment to be named icds-2.0.