### PR TITLE
env separation

### DIFF
--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -92,7 +92,7 @@
     src: localsettings.py.j2
     dest: "{{ item.path }}/localsettings.py"
   with_items:
-    - { path: "{{ code_home }}", deploy_env_name: "{{ deploy_env }}" }
+    - { path: "{{ code_home }}", deploy_env_name: "{{ env_name|default(deploy_env) }}" }
   tags:
     - localsettings
     - hq-localsettings
@@ -105,7 +105,7 @@
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
   with_items:
-    - { path: "{{ code_home }}", deploy_env_name: "{{ deploy_env }}" }
+    - { path: "{{ code_home }}", deploy_env_name: "{{ env_name|default(deploy_env) }}" }
   tags:
     - localsettings
     - hq-localsettings

--- a/ansible/roles/commcarehq/tasks/main.yml
+++ b/ansible/roles/commcarehq/tasks/main.yml
@@ -90,9 +90,7 @@
   become: true
   template:
     src: localsettings.py.j2
-    dest: "{{ item.path }}/localsettings.py"
-  with_items:
-    - { path: "{{ code_home }}", deploy_env_name: "{{ env_name|default(deploy_env) }}" }
+    dest: "{{ code_home }}/localsettings.py"
   tags:
     - localsettings
     - hq-localsettings
@@ -100,12 +98,10 @@
 - name: chown localsettings
   become: true
   file:
-    path: "{{ item.path }}/localsettings.py"
+    path: "{{ code_home }}/localsettings.py"
     state: file
     owner: "{{ cchq_user }}"
     group: "{{ cchq_user }}"
-  with_items:
-    - { path: "{{ code_home }}", deploy_env_name: "{{ env_name|default(deploy_env) }}" }
   tags:
     - localsettings
     - hq-localsettings

--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -105,8 +105,8 @@ EMAIL_SMTP_HOST = "{{ localsettings.EMAIL_SMTP_HOST }}"
 EMAIL_SMTP_PORT = {{ localsettings.EMAIL_SMTP_PORT }}
 {% endif %}
 
-EMAIL_SUBJECT_PREFIX = '[{{ item.deploy_env_name }}] '
-SERVER_ENVIRONMENT = '{{ item.deploy_env_name }}'
+EMAIL_SUBJECT_PREFIX = '[{{ env_name|default(deploy_env) }}] '
+SERVER_ENVIRONMENT = '{{ env_name|default(deploy_env) }}'
 
 XFORMS_FORM_TRANSLATE_JAR = os.path.join(_ROOT_DIR, "lib", "form_translate.jar")
 

--- a/ansible/roles/datadog/templates/elastic.yaml.j2
+++ b/ansible/roles/datadog/templates/elastic.yaml.j2
@@ -6,4 +6,4 @@ init_config:
 instances:
   - url: http://{{ inventory_hostname }}:9200
     tags:
-      - environment:{{ deploy_env }}
+      - environment:{{ env_name|default(deploy_env) }}

--- a/ansible/roles/datadog/templates/gunicorn.yaml.j2
+++ b/ansible/roles/datadog/templates/gunicorn.yaml.j2
@@ -6,4 +6,4 @@ init_config:
 instances:
   - proc_name: deployment.gunicorn.commcarehq_wsgi:application
     tags:
-      - environment:{{ deploy_env }}
+      - environment:{{ env_name|default(deploy_env) }}

--- a/ansible/roles/datadog/templates/jmx.yaml.j2
+++ b/ansible/roles/datadog/templates/jmx.yaml.j2
@@ -13,7 +13,7 @@ instances:
     name: jmx_formplayer_instance
 
     tags:
-      env: {{ deploy_env }}
+      env: {{ env_name|default(deploy_env) }}
       newTag: formplayer
 
     conf:

--- a/ansible/roles/datadog/templates/nginx.yaml.j2
+++ b/ansible/roles/datadog/templates/nginx.yaml.j2
@@ -6,4 +6,4 @@ init_config:
 instances:
   - nginx_status_url: http://localhost/nginx_stub_status/
     tags:
-      - environment:{{ deploy_env }}
+      - environment:{{ env_name|default(deploy_env) }}

--- a/ansible/roles/datadog/templates/pgbouncer.yaml.j2
+++ b/ansible/roles/datadog/templates/pgbouncer.yaml.j2
@@ -9,4 +9,4 @@ instances:
      username: {{ postgres_users.devreadonly.username }}
      password: {{ postgres_users.devreadonly.password }}
      tags:
-       - environment:{{ deploy_env }}
+       - environment:{{ env_name|default(deploy_env) }}

--- a/ansible/roles/datadog/templates/postgres.yaml.j2
+++ b/ansible/roles/datadog/templates/postgres.yaml.j2
@@ -10,4 +10,4 @@ instances:
        password: {{ postgres_users.devreadonly.password }}
        ssl: False
        tags:
-            - environment:{{ deploy_env }}
+            - environment:{{ env_name|default(deploy_env) }}

--- a/ansible/roles/datadog/templates/rabbitmq.yaml.j2
+++ b/ansible/roles/datadog/templates/rabbitmq.yaml.j2
@@ -8,6 +8,6 @@ instances:
     rabbitmq_user: {{ AMQP_USER }}
     rabbitmq_pass: {{ AMQP_PASSWORD }}
     tags:
-      - environment:{{ deploy_env }}
+      - environment:{{ env_name|default(deploy_env) }}
     vhosts:
       - {{ AMQP_NAME }}

--- a/ansible/roles/datadog/templates/redisdb.yaml.j2
+++ b/ansible/roles/datadog/templates/redisdb.yaml.j2
@@ -7,4 +7,4 @@ instances:
   - host: localhost
     port: 6379
     tags:
-      - environment:{{ deploy_env }}
+      - environment:{{ env_name|default(deploy_env) }}

--- a/ansible/roles/formplayer/templates/application.properties.j2
+++ b/ansible/roles/formplayer/templates/application.properties.j2
@@ -3,7 +3,7 @@ commcarehq.host=https://{{ ALTERNATE_FORMPLAYER_HQ_HOST }}
 {% else %}
 commcarehq.host=https://{{ SITE_HOST }}
 {% endif %}
-commcarehq.environment={{ deploy_env }}
+commcarehq.environment={{ env_name|default(deploy_env) }}
 commcarehq.formplayerAuthKey={{ localsettings.FORMPLAYER_INTERNAL_AUTH_KEY }}
 server.port={{ formplayer_port }}
 user.suffix=commcarehq.org

--- a/ansible/vars/dev/dev_public.yml
+++ b/ansible/vars/dev/dev_public.yml
@@ -48,7 +48,10 @@ active_sites:
   tableau: False
   cas_ssl: False
 
+# This is used for creating all physical resources e.g. /home/cchq/www/{{deploy_env}}
 deploy_env: dev
+# This is the name used for datadog and in settings.SERVER_ENVIRONMENT
+# env_name: dev1
 fake_ssl_cert: yes
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 


### PR DESCRIPTION
This separates what the env name is that's used in Datadog and Django from what the env that's used for any folders or files.

So we can have `/home/cchq/www/icds/` and have the env on Datadog be `icds-new`.

This seems like a reasonable separation to me.