### PR TITLE
auto upgrade pip

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -26,6 +26,7 @@ ansible-galaxy install -r ~/commcarehq-ansible/ansible/requirements.yml &
 pip install -r ~/commcarehq-ansible/ansible/requirements.txt &
 pip install -e ~/commcarehq-ansible/commcare-cloud &
 pip install -r ~/commcarehq-ansible/fab/requirements.txt &
+pip install pip --upgrade &
 wait
 
 # convenience: . init-ansible


### PR DESCRIPTION
I've had reports of people getting tripped up on having an old version of pip on their control env, and I've had this happen to me as well.

I think this is all we need to permanently fix it, unless anyone wants to advocate for the more conservative approach of pinning pip to a specific version, which I at this point think is probably overkill.