### PR TITLE
Fix supervisor config templating

### DIFF
--- a/fab/fab/operations/supervisor.py
+++ b/fab/fab/operations/supervisor.py
@@ -5,13 +5,14 @@ import os
 import time
 import posixpath
 from contextlib import contextmanager
+import uuid
 
 from fabric.api import roles, parallel, env, sudo, serial, execute
 from fabric.colors import magenta
 from fabric.context_managers import cd
 from fabric.contrib import files
 from fabric.decorators import task
-from fabric.operations import put
+from fabric.operations import put, run
 
 from ..const import (
     ROLES_CELERY,
@@ -209,18 +210,33 @@ def set_websocket_supervisorconf():
         _rebuild_supervisor_conf_file('make_supervisor_conf', 'supervisor_websockets.conf')
 
 
+def please_put(local_dir, remote_dir, temp_dir='/tmp'):
+    remote_temp_dir = os.path.join(temp_dir, 'please-put-{}'.format(uuid.uuid4().hex))
+
+    sudo('rm -rf {}'.format(remote_dir))
+    sudo('mkdir -p {}'.format(os.path.dirname(remote_dir)))
+
+    run('rm -rf {}'.format(remote_temp_dir))
+    run('mkdir -p {}'.format(remote_temp_dir))
+
+    put(local_dir, remote_temp_dir)
+
+    sudo('cp -r {} {}'.format(os.path.join(remote_temp_dir, os.path.basename(local_dir)), remote_dir))
+
+    run('rm -rf {}'.format(remote_temp_dir))
+
+
 def _rebuild_supervisor_conf_file(conf_command, filename, params=None, conf_destination_filename=None):
     remote_service_template_dir = os.path.join(env.code_root, 'deployment', 'commcare-hq-deploy', 'fab', 'services', 'templates')
     local_service_template_dir = os.path.join(os.path.dirname(__file__), '..', 'services', 'templates')
 
-    sudo('mkdir -p {}'.format(posixpath.join(env.services, 'supervisor')))
-    sudo('mkdir -p {}'.format(remote_service_template_dir))
-    # useful in interim where commcare-hq-deploy still exists
-    sudo('rm {}/*'.format(remote_service_template_dir))
     # put the commcarehq-ansible/fab/fab/services/templates directory
     # in the legacy commcare-hq-deploy location
     # so that the make_supervisor*_conf management commands know where to find it
-    put(local_service_template_dir, remote_service_template_dir, use_sudo=True)
+    please_put(local_service_template_dir, remote_service_template_dir)
+
+    sudo('mkdir -p {}'.format(posixpath.join(env.services, 'supervisor')))
+
     if filename in env.get('service_blacklist', []):
         print(magenta('Skipping {} because the service has been blacklisted'.format(filename)))
         return

--- a/fab/fab/operations/supervisor.py
+++ b/fab/fab/operations/supervisor.py
@@ -215,6 +215,8 @@ def _rebuild_supervisor_conf_file(conf_command, filename, params=None, conf_dest
 
     sudo('mkdir -p {}'.format(posixpath.join(env.services, 'supervisor')))
     sudo('mkdir -p {}'.format(remote_service_template_dir))
+    # useful in interim where commcare-hq-deploy still exists
+    sudo('rm {}/*'.format(remote_service_template_dir))
     # put the commcarehq-ansible/fab/fab/services/templates directory
     # in the legacy commcare-hq-deploy location
     # so that the make_supervisor*_conf management commands know where to find it

--- a/fab/fab/operations/supervisor.py
+++ b/fab/fab/operations/supervisor.py
@@ -10,6 +10,7 @@ from fabric.api import roles, parallel, env, sudo, serial, execute
 from fabric.colors import magenta
 from fabric.context_managers import cd
 from fabric.contrib import files
+from fabric.decorators import task
 from fabric.operations import put
 
 from ..const import (
@@ -29,6 +30,7 @@ from ..utils import get_pillow_env_config, get_inventory
 from six.moves import range
 
 
+@task
 @roles(ROLES_ALL_SERVICES)
 @parallel
 def set_supervisor_config():


### PR DESCRIPTION
new strategy is to copy fab/fab/services/templates/ to the legacy commcare-hq-deploy location on the remote server
and then let the make_supervisor*_conf management commands take it from there without being any the wiser

We can discuss how we want to do this long term—maybe it's time to move services out of the app deploy and into ansible?—but right now deploy is broken, and this is the lowest-touch fix.