### PR TITLE
make fab require being in the commcarehq-ansible repo

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -36,8 +36,6 @@ alias ap='ansible-playbook -u ansible -i ~/commcarehq-ansible/fab/fab/inventory/
 alias aps='ap deploy_stack.yml'
 alias update-code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 alias update_code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
-# so that you can run fab from any directory
-alias fab="fab -f ~/commcarehq-ansible/fab/fabfile.py"
 
 [ ! -f ~/.bash_completion ] && source  ~/commcarehq-ansible/control/.bash_completion
 cp ~/commcarehq-ansible/control/.bash_completion ~/
@@ -76,4 +74,4 @@ function ansible-control-banner() {
 }
 
 [ -t 1 ] && ansible-control-banner
-cd ~/commcarehq-ansible/ansible
+cd ~/commcarehq-ansible

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'fab'))
+from fab.fabfile import *


### PR DESCRIPTION
and go along with the fab convention rather than using the error-prone alias.

This also makes `~/commcarehq-ansible` rather than `~/commcarehq-ansible/ansible` the default starting directory on the control machine. This shouldn't affect any of the normal workflows, as `commcare-cloud` works fine from anywhere (right down to autocompleting playbook file names).