### PR TITLE
Add `cchq` alias for `commcare-cloud` tool

### DIFF
--- a/commcare-cloud/setup.py
+++ b/commcare-cloud/setup.py
@@ -7,7 +7,10 @@ setup(
     license='BSD-3',
     packages=find_packages('.'),
     entry_points={
-        'console_scripts': ['commcare-cloud = commcare_cloud:main'],
+        'console_scripts': [
+            'commcare-cloud = commcare_cloud:main',
+            'cchq = commcare_cloud:main',
+        ],
     },
     install_requires=(
         'six',

--- a/control/.bash_completion
+++ b/control/.bash_completion
@@ -53,3 +53,4 @@ _commcare_cloud()
     esac
 }
 complete -F _commcare_cloud commcare-cloud
+complete -F _commcare_cloud cchq


### PR DESCRIPTION
Why? Because `commcare-cloud` is too long to type and doesn't auto-complete nicely
```
$ com<TAB><TAB>
comm            commcare-cloud/ compile-et.pl   complete
command         compgen         compile_et      compress
$ comm<TAB><TAB>
comm            command         commcare-cloud/
```

@dannyroberts 