### PR TITLE
add example (imaginary) migration spec for recent icds migration

### DIFF
--- a/environments/icds-new/migrations/2017-12-01-initial/README.md
+++ b/environments/icds-new/migrations/2017-12-01-initial/README.md
@@ -1,0 +1,29 @@
+These files represent the initial version of a proposed spec for automating a datacenter migration. Note that there are no tools built around this yet.
+
+Imagine something like
+
+```
+commcare-cloud icds migration 2017-12-01-initial run postgresql
+```
+
+which would look at the mapping you'd specified of postgresql machines and initiate pairwise rsyncs. And then maybe
+
+```
+commcare-cloud icds migration 2017-12-01-initial check postgresql
+```
+
+would show you some progress information about the ongoing migration, as well as useful information like what logfiles to check to see the raw output of rsync commands, etc. for debugging. Anyway, that's the dream.
+
+## The format
+
+- the big file `couchdb2-cluster-plan.yml` is just the plan file from `couchdb-cluster-admin` converted to YAML. This outlines the sharding plan that `couchdb-cluster-admin` will eventually commit, and thus also which data needs to be copied to which machine.
+- the `role-mapping.yml` file is really the payload here. It outlines for each data service which machine-to-machine data transfers need to happen. You can read it as saying "for the purposes of `postgresql`, `icds` `pg1` corresponds to `icds-new` `pgmain`", "for the purposes of `riackcs`, `icds` `pg1` corresponds to `icds-new` `riak0`", etc.
+
+## The rationale
+Thinking back to the data-migration part of the migration, I'm pretty sure that this right here captures most if not all of what a computer would need to know about the particulars of that migration in order to run it automatically, or at least run parts of it automatically though commands like the ones above.
+
+The other nice thing is that even before we add any super-sophisticated automation, having this down in a spec can:
+- let people manually verify that they're migrating to and from the right IPs—it's right here in the spec what's supposed to go where
+- let people write scripts that generate the rsync commands that they should manually run (instead of manually copying and pasting IP addresses to form the commands themselves)
+- leave a simple formal record of what was supposed to happen in each migration.
+- serve as a focal point for building simple tools around that will eventually snowball into something super useful

--- a/environments/icds-new/migrations/2017-12-01-initial/couchdb2-shard-plan.yml
+++ b/environments/icds-new/migrations/2017-12-01-initial/couchdb2-shard-plan.yml
@@ -1,0 +1,307 @@
+commcarehq:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824481'
+commcarehq__apps:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824505'
+commcarehq__auditcare:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824517'
+commcarehq__domains:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824538'
+commcarehq__fixtures:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495821829'
+commcarehq__meta:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824551'
+commcarehq__receiverwrapper:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824576'
+commcarehq__synclogs:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    40000000-5fffffff:
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    a0000000-bfffffff:
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+  shard_suffix: '.1495825115'
+commcarehq__users:
+  by_range:
+    00000000-1fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    20000000-3fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    40000000-5fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    60000000-7fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    80000000-9fffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    a0000000-bfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    c0000000-dfffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+    e0000000-ffffffff:
+    - couchdb@10.247.164.12
+    - couchdb@10.247.164.5
+    - couchdb@10.247.164.14
+  shard_suffix: '.1495824261'

--- a/environments/icds-new/migrations/2017-12-01-initial/role-mapping.yml
+++ b/environments/icds-new/migrations/2017-12-01-initial/role-mapping.yml
@@ -1,0 +1,31 @@
+postgresql:
+  transfer:
+    icds.pg0: pgucr
+    icds.pg1: pgmain
+    icds.pg2: pgshard1
+    icds.pg3: pgshard2
+
+couchdb2:
+  # Does a selective rsync based on couchdb2-shard-plan.yml
+  reshard:
+    icds.couch0:
+      - couch0
+      - couch1
+      - couch2
+
+elasticsearch:
+  transfer:
+    icds.es0: es0
+    icds.es1: es1
+    icds.es2: es2
+    icds.es3: es3
+
+riakcs:
+  transfer:
+    icds.pg1: riak0
+    icds.es0: riak1
+    icds.es1: riak2
+    icds.es2: riak3
+    icds.es3: riak4
+    icds.pg2: riak5
+    icds.pg3: riak6


### PR DESCRIPTION
Hey @snopoke, I think I had originally mused about this with you during the recent ICDS migration, that it would be awesome if in the future we could write a "spec" for the migration and then write automation that works off of that. Imagine something like

```
commcare-cloud icds migration 2017-12-01-initial run postgresql
```

which would look at the mapping you'd specified of postgresql machines and initiate pairwise rsyncs. And then maybe

```
commcare-cloud icds migration 2017-12-01-initial check postgresql
```

would show you some progress information about the ongoing migration, as well as useful information like what logfiles to check to see the raw output of rsync commands, etc. for debugging. Anyway, that's the dream.

## The format

Anyway, I took a crack at writing down a file format for this stuff.

- the big file `couchdb2-cluster-plan.yml` is just the plan file from `couchdb-cluster-admin` self-indulgently converted to YAML. This outlines the sharding plan that `couchdb-cluster-admin` will eventually commit, and thus also which data needs to be copied to which machine.
- the `role-mapping.yml` file is really the payload here. It outlines for each data service which machine-to-machine data transfers need to happen. You can read it as saying "for the purposes of `postgresql`, `icds` `pg1` corresponds to `icds-new` `pgmain`", "for the purposes of `riackcs`, `icds` `pg1` corresponds to `icds-new` `riak0`", etc.

## The rationale
Thinking back to the data-migration part of the migration, I'm pretty sure that this right here captures most if not all of what a computer would need to know about the particulars of that migration in order to run it automatically, or at least run parts of it automatically though commands like the ones above.

The other nice thing is that even before we add any super-sophisticated automation, having this down in a spec can:
- let people manually verify that they're migrating to and from the right IPs—it's right here in the spec what's supposed to go where
- let people write scripts that generate the rsync commands that they should manually run (instead of manually copying and pasting IP addresses to form the commands themselves)
- leave a simple formal record of what was supposed to happen in each migration.
- serve as a focal point for building simple tools around that will eventually snowball into something super useful
  
Let me know what you think!