### PR TITLE
commcare-cloud lookup and arg clarification

### DIFF
--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -517,9 +517,9 @@ class Lookup(object):
     @classmethod
     def make_parser(cls, parser):
         cls.parser = parser
-        parser.add_argument("group",
-            help="Server group: postgresql, proxy, webworkers, ... The server "
-                 "group may be prefixed with 'username@' to login as a specific "
+        parser.add_argument("server",
+            help="Server name/group: postgresql, proxy, webworkers, ... The server "
+                 "name/group may be prefixed with 'username@' to login as a specific "
                  "user and may be terminated with ':<n>' to choose one of "
                  "multiple servers if there is more than one in the group. "
                  "For example: webworkers:0 will pick the first webworker.")

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -510,9 +510,9 @@ class Fab(object):
             puts(colored.red(u"✗ Fab failed with status code {}".format(exit_code)))
 
 
-class Ssh(object):
-    command = 'ssh'
-    help = "Connect to a remote host with ssh"
+class Lookup(object):
+    command = 'lookup'
+    help = "Lookup remote hostname or IP address"
 
     @classmethod
     def make_parser(cls, parser):
@@ -525,10 +525,27 @@ class Ssh(object):
                  "For example: webworkers:0 will pick the first webworker.")
 
     @classmethod
-    def run(cls, args, ssh_args):
+    def lookup_server_address(cls, args):
         def exit(message):
             cls.parser.error("\n" + message)
-        address = get_server_address(args.environment, args.group, exit)
+        return get_server_address(args.environment, args.server, exit)
+
+    @classmethod
+    def run(cls, args, unknown_args):
+        if unknown_args:
+            sys.stderr.write(
+                "Ignoring extra argument(s): {}\n".format(unknown_args)
+            )
+        print(cls.lookup_server_address(args))
+
+
+class Ssh(Lookup):
+    command = 'ssh'
+    help = "Connect to a remote host with ssh"
+
+    @classmethod
+    def run(cls, args, ssh_args):
+        address = cls.lookup_server_address(args)
         cmd_parts = [cls.command, address] + ssh_args
         cmd = ' '.join(shlex_quote(arg) for arg in cmd_parts)
         print(cmd)
@@ -570,6 +587,7 @@ STANDARD_ARGS = [
     RunShellCommand,
     RunAnsibleModule,
     Fab,
+    Lookup,
     Ssh,
     Mosh,
 ]

--- a/commcare-cloud/commcare_cloud/getinventory.py
+++ b/commcare-cloud/commcare_cloud/getinventory.py
@@ -49,7 +49,7 @@ def get_server_address(environment, group, exit=sys.exit):
     except IOError as err:
         exit(err)
     except KeyError as err:
-        exit("Unknown group: {}\n".format(group))
+        exit("Unknown server name/group: {}\n".format(group))
 
     if index is not None and index > len(servers) - 1:
         exit(


### PR DESCRIPTION
Feedback from #1222

I thought about re-adding `scripts/inventory/getinventory.py` with contents:
```sh
#!/usr/bin/env bash
# DEPRECATED use commcare-cloud <env> lookup [<user>@]<group>[:<n>]
_env=$1
shift  # drop environment arg
commcare-cloud $_env lookup "$@"
```
But putting a bash script in a `.py` file felt dirty and I doubt anyone will really miss it. Let me know if you think it's still necessary.

@dannyroberts 