### PR TITLE
move hardcoded public IP to inventory file

### DIFF
--- a/environments/icds-new/inventory.ini
+++ b/environments/icds-new/inventory.ini
@@ -185,6 +185,7 @@ postgresql_default_statistics_target = 100
 [web0:vars]
 parent_mailrelay='relay.nic.in'
 hostname='web0'
+public_ip=164.100.59.184
 
 [web1]
 10.247.164.32

--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -269,7 +269,8 @@ localsettings:
     - 127.0.0.1
     - '{{ SITE_HOST }}'
     - '{{ CAS_SITE_HOST }}'
-    - '164.100.59.184'
+    - '{{ hostvars[groups.proxy.0].public_ip }}'
+
   ASYNC_INDICATORS_TO_QUEUE: 120000
   ASYNC_INDICATOR_QUEUE_CRONTAB:
     minute: '*/5'


### PR DESCRIPTION
Small, but I remember this tripped me up during the migration. I checked that `commcare-cloud icds-new update-config`'s check mode doesn't show any diffs in localsettings.py (and then I didn't apply).