### PR TITLE
Experiment: Allow for default public variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
   - ".travis/tests.sh"
   - "diff <(ansible -h) commcare-cloud/commcare_cloud/help_cache/ansible.txt"
   - "diff <(ansible-playbook -h) commcare-cloud/commcare_cloud/help_cache/ansible-playbook.txt"
+  - "./commcare-cloud/tests/test_vars.sh"

--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -18,6 +18,7 @@ from .paths import (
     ANSIBLE_DIR,
     ENVIRONMENTS_DIR,
     FABFILE,
+    get_consolidated_public_vars_filepath,
     get_inventory_filepath,
     get_public_vars_filepath,
     get_vault_vars_filepath,
@@ -579,14 +580,9 @@ class CheckVars(object):
         if consolidated != expected:
             consolidated_pretty = yaml.safe_dump(consolidated, default_flow_style=False)
             expected_pretty = yaml.safe_dump(expected, default_flow_style=False)
-            consolidated_filepath = os.path.join(
-                os.path.dirname(get_public_vars_filepath(args.environment)),
-                '.consolidated-public.yml'
-            )
+            consolidated_filepath = get_consolidated_public_vars_filepath(args.environment)
             expected_pretty_filepath = os.path.join(
-                os.path.dirname(get_public_vars_filepath(args.environment)),
-                '.expected-pretty-public.yml'
-            )
+                os.path.dirname(consolidated_filepath), '.expected-pretty-public.yml')
             with open(consolidated_filepath, 'w') as f:
                 f.write(consolidated_pretty)
             with open(expected_pretty_filepath, 'w') as f:

--- a/commcare-cloud/commcare_cloud/paths.py
+++ b/commcare-cloud/commcare_cloud/paths.py
@@ -4,6 +4,7 @@ import sys
 REPO_BASE = os.path.expanduser('~/.commcare-cloud/repo')
 ANSIBLE_DIR = os.path.join(REPO_BASE, 'ansible')
 ENVIRONMENTS_DIR = os.path.join(REPO_BASE, 'environments')
+ENVIRONMENTAL_DEFAULTS_DIR = os.path.join(REPO_BASE, 'environmental-defaults')
 FAB_DIR = os.path.join(REPO_BASE, 'fab')
 FABFILE = os.path.join(REPO_BASE, 'fabfile.py')
 

--- a/commcare-cloud/commcare_cloud/paths.py
+++ b/commcare-cloud/commcare_cloud/paths.py
@@ -13,6 +13,10 @@ def get_public_vars_filepath(environment):
     return os.path.join(ENVIRONMENTS_DIR, environment, 'public.yml')
 
 
+def get_consolidated_public_vars_filepath(environment):
+    return os.path.join(ENVIRONMENTS_DIR, environment, '.consolidated-public.yml')
+
+
 def get_vault_vars_filepath(environment):
     return os.path.join(ENVIRONMENTS_DIR, environment, 'vault.yml')
 

--- a/commcare-cloud/commcare_cloud/var_files.py
+++ b/commcare-cloud/commcare_cloud/var_files.py
@@ -1,0 +1,36 @@
+import os
+import yaml
+from .paths import ENVIRONMENTAL_DEFAULTS_DIR, get_public_vars_filepath, ENVIRONMENTS_DIR
+
+
+def get_consolidated_vars(environment):
+    with open(os.path.join(ENVIRONMENTAL_DEFAULTS_DIR, 'public.yml')) as f:
+        default_vars = yaml.load(f)
+    with open(get_public_vars_filepath(environment)) as f:
+        custom_vars = yaml.load(f)
+
+    consolidated_vars = {}
+    if default_vars:
+        deep_update(consolidated_vars, default_vars)
+    deep_update(consolidated_vars, custom_vars)
+    return consolidated_vars
+
+
+def deep_update(base, extra):
+    for key, new_value in extra.items():
+        if isinstance(new_value, dict) and isinstance(base.get(key), dict):
+            deep_update(base[key], new_value)
+        else:
+            base[key] = new_value
+
+
+def get_public_vars(environment):
+    filename = get_public_vars_filepath(environment)
+    with open(filename) as f:
+        return yaml.load(f)
+
+
+def get_expected_public_vars(environment):
+    filename = os.path.join(ENVIRONMENTS_DIR, environment, 'expected-public.yml')
+    with open(filename) as f:
+        return yaml.load(f)

--- a/commcare-cloud/commcare_cloud/var_files.py
+++ b/commcare-cloud/commcare_cloud/var_files.py
@@ -1,6 +1,7 @@
 import os
 import yaml
-from .paths import ENVIRONMENTAL_DEFAULTS_DIR, get_public_vars_filepath, ENVIRONMENTS_DIR
+from .paths import ENVIRONMENTAL_DEFAULTS_DIR, get_public_vars_filepath, ENVIRONMENTS_DIR, \
+    get_consolidated_public_vars_filepath
 
 
 def get_consolidated_vars(environment):
@@ -16,18 +17,21 @@ def get_consolidated_vars(environment):
     return consolidated_vars
 
 
+def create_consolidated_vars_file(environment):
+    consolidated = get_consolidated_vars(environment)
+    consolidated_pretty = yaml.safe_dump(consolidated, default_flow_style=False)
+    consolidated_filepath = get_consolidated_public_vars_filepath(environment)
+    with open(consolidated_filepath, 'w') as f:
+        f.write(consolidated_pretty)
+    return consolidated, consolidated_filepath
+
+
 def deep_update(base, extra):
     for key, new_value in extra.items():
         if isinstance(new_value, dict) and isinstance(base.get(key), dict):
             deep_update(base[key], new_value)
         else:
             base[key] = new_value
-
-
-def get_public_vars(environment):
-    filename = get_public_vars_filepath(environment)
-    with open(filename) as f:
-        return yaml.load(f)
 
 
 def get_expected_public_vars(environment):

--- a/commcare-cloud/tests/test_vars.sh
+++ b/commcare-cloud/tests/test_vars.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+possible_envs=$(commcare-cloud -h | head -n2 | tail -n1 | cut -d'{' -f2 | cut -d'}' -f1 | sed 's/,/ /g')
+for env in ${possible_envs}
+do
+    echo ${env}
+    commcare-cloud ${env} _checkvars
+done

--- a/commcare-cloud/tests/test_vars.sh
+++ b/commcare-cloud/tests/test_vars.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 possible_envs=$(commcare-cloud -h | head -n2 | tail -n1 | cut -d'{' -f2 | cut -d'}' -f1 | sed 's/,/ /g')
+status_code=0
 for env in ${possible_envs}
 do
     echo ${env}
-    commcare-cloud ${env} _checkvars
+    commcare-cloud ${env} _checkvars || status_code=$?
 done
+exit ${status_code}

--- a/environmental-defaults/public.yml
+++ b/environmental-defaults/public.yml
@@ -1,0 +1,18 @@
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_www_redirect_insecure: True
+  cchq_http_j2me: True
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech2: False
+  riakcs: False
+  cas_ssl: False
+  couchdb2: False
+  enikshay_ssl: False

--- a/environments/.gitignore
+++ b/environments/.gitignore
@@ -1,0 +1,2 @@
+.consolidated-public.yml
+.expected-pretty-public.yml

--- a/environments/enikshay/expected-public.yml
+++ b/environments/enikshay/expected-public.yml
@@ -21,6 +21,8 @@ active_sites:
   motech2: False
   riakcs: True
   enikshay_ssl: True
+  cas_ssl: False
+  couchdb2: False
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"

--- a/environments/enikshay/expected-public.yml
+++ b/environments/enikshay/expected-public.yml
@@ -1,0 +1,322 @@
+SITE_HOST: 'enikshay.in'
+ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
+J2ME_SITE_HOST: 'j2me.enikshay.in'
+deploy_env: enikshay
+internal_domain_name: 'enikshay.in'
+daily_deploy_email: tech-announce-daily@dimagi.com
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: False
+  cchq_http: True
+  cchq_www_redirect_insecure: False
+  cchq_http_j2me: True
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech2: False
+  riakcs: True
+  enikshay_ssl: True
+
+couchdb2:
+  username: "{{ localsettings_private.COUCH_USERNAME }}"
+  password: "{{ localsettings_private.COUCH_PASSWORD }}"
+
+riak_backend: "leveldb-bad-config"
+riak_ring_size: 128
+
+riakcs_proxy_port_override: 9980
+riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
+riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
+
+primary_ssl_env: "enikshay.in"
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+msp_users: "{{ secrets.MSP_USERS }}"
+fake_ssl_cert: no
+
+run_newrelic_plugin_agent: False
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+datadog_integration_cloudant: False
+datadog_integration_vmware: True
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_memory: '8192m'
+elasticsearch_cluster_name: 'enikshayes-1.x'
+
+nginx_key_file: '../config/{{ deploy_env }}/ssl/enikshay.in.key'
+nginx_key_value: '{{ ssl_secrets.private_keys.enikshay_in }}'
+# Nginx only accepts on cert, so cat the site cert and chain:
+# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
+nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/enikshay.in.combined.crt'
+nginx_combined_cert_value: "{{ ssl_secrets.certs.enikshay_in }}"
+
+enikshay_nginx_combined_cert_file: '../config/{{ deploy_env}}/ssl/enikshay.commcarehq.org.combined.crt'
+enikshay_nginx_combined_cert_value: '{{ ssl_secrets.certs.enikshay_commcarehq_org }}'
+enikshay_key_file: '../config/{{ deploy_env }}/ssl/enikshay.commcarehq.org.key'
+enikshay_key_value: '{{ ssl_secrets.private_keys.enikshay_commcarehq_org }}'
+
+formplayer_sentry_dsn: '{{ secrets.FORMPLAYER_SENTRY_DSN }}'
+
+supervisor_http_enabled: True
+supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"
+supervisor_http_password: "{{ secrets.SUPERVISOR_HTTP_PASSWORD }}"
+
+keystore_file: '../config/DimagiKeyStore'
+
+encrypted_root: '/opt/data'
+
+backup_blobdb: False
+backup_postgres: plain
+postgresql_backup_days: 1
+postgresql_backup_weeks: 1
+postgresql_backup_master: False
+postgresql_log_directory: "{{ encrypted_root }}/pg_log"
+backup_es: False
+postgres_s3: False
+backup_couch: True
+nadir_hour: 16
+
+nofile_limit: 65536
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_num_logs_to_keep: 100
+postgresql_shared_buffers: '10GB'
+postgresql_max_stack_depth: '6MB'
+postgresql_effective_cache_size: '32GB'
+postgresql_work_mem: '16MB'
+postgresql_max_connections: 600
+postgresql_checkpoint_segments: 32
+postgresql_wal_keep_segments: 8
+pgstandby_wal_keep_segments: 500
+pgbouncer_max_connections: 1600
+pgbouncer_default_pool: 500
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+pg_query_stats: True
+
+formplayer_db_name: formplayer
+formplayer_archive_time_spec: '10m'
+formplayer_purge_time_spec: '8d'
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: proxy
+    name: commcarehq_proxy
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 103]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [104, 205]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [206, 308]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [309, 411]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [412, 514]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p6
+    name: commcarehq_p6
+    shards: [515, 617]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p7
+    name: commcarehq_p7
+    shards: [618, 720]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p8
+    name: commcarehq_p8
+    shards: [721, 823]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p9
+    name: commcarehq_p9
+    shards: [824, 926]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p10
+    name: commcarehq_p10
+    shards: [927, 1023]
+    host: "{{ groups.postgresql.0 }}"
+  - name: commcarehq_ucr
+    query_stats: True
+    host: "{{ groups.postgresql.0 }}"
+    django_alias: ucr
+    django_migrate: False
+  - name: "{{ formplayer_db_name }}"
+    host: "{{ groups.postgresql.0 }}"
+
+postgresql_ssl_enabled: False
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "{{ groups.rabbitmq.0 }}"
+AMQP_NAME: commcarehq
+
+kafka_broker_id: 0
+
+ufw_private_interface: eth0
+
+control_machine_ip: 172.25.3.5
+
+etc_hosts_lines: ['172.25.1.5 enikshay.in enikshay.commcarehq.org']
+etc_hosts_lines_removed: []
+
+nameservers:
+  - 8.8.8.8
+  - 8.8.4.4
+
+shared_drive_enabled: true
+
+# adding missing variables compared to icds 
+#http_proxy_address: '172.25.3.6' # use pg_standby as the patch server
+#http_proxy_port: '3128'
+
+couch_dbs:
+  default:
+    host: "{{ groups.couchdb2_proxy[0] }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+localsettings:
+  ALLOWED_HOSTS:
+    - localhost
+    - 127.0.0.1
+    - "{{ ENIKSHAY_SITE_HOST }}"
+    - "{{ SITE_HOST }}"
+    - "{{ J2ME_SITE_HOST }}"
+  ASYNC_INDICATORS_TO_QUEUE: 30000
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
+  CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
+  CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CELERY_TIMEZONE: 'Asia/Kolkata'
+  COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
+  COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
+  COUCH_STALE_QUERY: 'update_after'
+  DEPLOY_MACHINE_NAME: "{{ inventory_hostname }}"
+  DROPBOX_APP_NAME: 'CommCareHQFiles'
+  DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"
+  DROPBOX_SECRET: "{{ localsettings_private.DROPBOX_SECRET }}"
+  ELASTICSEARCH_HOST: "{{ groups.elasticsearch.0 }}"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_SMTP_HOST: 'localhost'
+  EMAIL_SMTP_PORT: 25
+  EMAIL_USE_TLS: no
+  ENABLE_DRACONIAN_SECURITY_FEATURES: yes
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: '{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}'
+  HQ_INSTANCE: 'enikshay'
+  HQ_PRIVATE_KEY: "{{ localsettings_private.HQ_PRIVATE_KEY }}"
+  INACTIVITY_TIMEOUT: 20160
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: Enikshay-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
+  KAFKA_URL: "{{ groups.kafka.0 }}"
+#  MAPS_LAYERS:
+  MAX_RULE_UPDATES_IN_ONE_RUN: 500000
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+  PILLOWTOP_MACHINE_ID: enikshaycloud
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: True
+  REPORTING_DATABASES:
+    ucr: ucr
+  AMAZON_S3_ACCESS_KEY: "{{ localsettings_private.AMAZON_S3_ACCESS_KEY }}"
+  AMAZON_S3_SECRET_KEY: "{{ localsettings_private.AMAZON_S3_SECRET_KEY }}"
+  SAVED_EXPORT_ACCESS_CUTOFF: 180
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+#  SIMPLE_API_KEYS:
+  SMS_GATEWAY_PARAMS:
+  SMS_GATEWAY_URL: ''
+  SMS_QUEUE_ENABLED: True
+#  STATIC_ROOT:
+  STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"
+  STRIPE_PUBLIC_KEY: "{{ localsettings_private.STRIPE_PUBLIC_KEY }}"
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  TRANSFER_SERVER: 'nginx'
+  USE_PARTITIONED_DATABASE: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  XFORMS_PLAYER_URL: "http://{{ groups.touchforms.0 }}:4444/"
+  ENABLE_PRELOGIN_SITE: False
+  ENIKSHAY_PRIVATE_API_USERS: {'BI': 'ppia-bi21', 'GU': 'ppia-gu21', 'MH': 'ppia-mh14'}
+  ENIKSHAY_PRIVATE_API_PASSWORD: "{{ localsettings_private.ENIKSHAY_PRIVATE_API_PASSWORD }}"
+  OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE: True
+  RESTRICT_USED_PASSWORDS_FOR_NIC_COMPLIANCE: True
+  ENTERPRISE_MODE: True
+  COMMCARE_HQ_NAME: 'eNikshay'
+  COMMCARE_NAME: 'eNikshay'

--- a/environments/enikshay/public.yml
+++ b/environments/enikshay/public.yml
@@ -6,19 +6,8 @@ internal_domain_name: 'enikshay.in'
 daily_deploy_email: tech-announce-daily@dimagi.com
 
 active_sites:
-  cchq_ssl: True
   cchq_www_redirect_secure: False
-  cchq_http: True
   cchq_www_redirect_insecure: False
-  cchq_http_j2me: True
-  commtrack_ssl: False
-  commtrack_http: False
-  tableau: False
-  icds_tableau: False
-  wiki: False
-  wiki_http: False
-  motech: False
-  motech2: False
   riakcs: True
   enikshay_ssl: True
 

--- a/environments/icds-new/expected-public.yml
+++ b/environments/icds-new/expected-public.yml
@@ -1,0 +1,429 @@
+SITE_HOST: 'www.icds-cas.gov.in'
+CAS_SITE_HOST: 'cas.commcarehq.org'
+NO_WWW_SITE_HOST: 'icds-cas.gov.in'
+deploy_env: icds
+env_name: icds-new
+internal_domain_name: 'internal-icds-new.commcarehq.org'
+cluster_ip_range: '10.247.164.0/23'
+
+tableau_server: 10.247.24.11:80
+daily_deploy_email: tech-announce-daily@dimagi.com
+
+TABLEAU_HOST: 'reports.icds-cas.gov.in'
+
+nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
+nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'
+
+cas_nginx_combined_cert_value: "{{ ssl_secrets.certs.cas_commcarehq_org }}"
+cas_key_value: '{{ ssl_secrets.private_keys.cas_commcarehq_org }}'
+
+tableau_nginx_combined_cert_value: "{{ ssl_secrets.certs.reports_icds_cas_gov_in }}"
+tableau_key_value: '{{ ssl_secrets.private_keys.reports_icds_cas_gov_in }}'
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_www_redirect_insecure: True
+  cchq_http_j2me: False
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: True
+  dhis: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech1: False
+  motech2: False
+  riakcs: True
+  cas_ssl: True
+
+riak_backend: "bitcask"
+riak_ring_size: 64
+
+riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
+riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
+
+primary_ssl_env: "cas"
+nginx_max_clients: 1024
+nginx_worker_rlimit_nofile : 16384
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+elasticsearch_endpoint: '{{ groups.es0.0 }}'
+elasticsearch_cluster_name: 'icds-2.0'
+
+formplayer_sentry_dsn: '{{ secrets.FORMPLAYER_SENTRY_DSN }}'
+
+supervisor_http_enabled: True
+supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"
+supervisor_http_password: "{{ secrets.SUPERVISOR_HTTP_PASSWORD }}"
+
+# keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: plain
+backup_es: False
+postgres_s3: False
+couch_s3: False
+backup_couch: False
+nadir_hour: 16
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_version: '9.6'
+postgresql_shared_buffers: '8GB'
+postgresql_max_stack_depth: '6MB'
+postgresql_effective_cache_size: '16GB'
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+pg_query_stats: True
+
+formplayer_db_name: formplayer
+
+nofile_limit: 65536
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+    host: "{{ hostvars[groups.pgmain.0].inventory_hostname }}"
+  - django_alias: proxy
+    name: commcarehq_proxy
+    host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 103]
+    host: "{{ hostvars[groups.pgshard2.0].inventory_hostname }}"
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [104, 205]
+    host: "{{ hostvars[groups.pgshard2.0].inventory_hostname }}"
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [206, 308]
+    host: "{{ hostvars[groups.pgshard2.0].inventory_hostname }}"
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [309, 411]
+    host: "{{ hostvars[groups.pgshard2.0].inventory_hostname }}"
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [412, 514]
+    host: "{{ hostvars[groups.pgshard2.0].inventory_hostname }}"
+  - django_alias: p6
+    name: commcarehq_p6
+    shards: [515, 617]
+    host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
+    query_stats: True
+  - django_alias: p7
+    name: commcarehq_p7
+    shards: [618, 720]
+    host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
+  - django_alias: p8
+    name: commcarehq_p8
+    shards: [721, 823]
+    host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
+  - django_alias: p9
+    name: commcarehq_p9
+    shards: [824, 926]
+    host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
+  - django_alias: p10
+    name: commcarehq_p10
+    shards: [927, 1023]
+    host: "{{ hostvars[groups.pgshard1.0].inventory_hostname }}"
+  - name: commcarehq_ucr
+    host: "{{ hostvars[groups.pgucr.0].inventory_hostname }}"
+    django_alias: ucr
+    django_migrate: False
+  - django_alias: icds-ucr
+    name: commcarehq_icds_aggregatedata
+    host: "{{ hostvars[groups.pgucr.0].inventory_hostname }}"
+    query_stats: True
+  - name: commcarehq_icds_testdata
+    host: "{{ hostvars[groups.pgucr.0].inventory_hostname }}"
+  - name: "{{ formplayer_db_name }}"
+    host: "{{ hostvars[groups.pgucr.0].inventory_hostname }}"
+  - django_alias: icds-ucr-standby1
+    name: commcarehq_icds_aggregatedata
+    host: "{{ hostvars[groups.pgucrstandby.0].inventory_hostname }}"
+    create: False
+    django_migrate: False
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+kafka_log_dir: '/opt/data/kafka'
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: no
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "{{ groups.rabbit0.0 }}"
+AMQP_NAME: commcarehq
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+datadog_integration_cloudant: False
+datadog_integration_vmware: True
+
+file_email: False
+
+ufw_private_interface: eth0
+
+shared_drive_enabled: true
+
+touchforms_enabled: false
+
+etc_hosts_lines:
+  - '10.247.164.31		cas.commcarehq.org'
+  - '10.247.164.31		reports.icds-cas.gov.in'
+  - '10.247.164.31		www.icds-cas.gov.in'
+etc_hosts_lines_removed: []
+
+nameservers:
+  - 164.100.17.3
+  - 164.100.3.1
+
+http_proxy_address: '10.247.63.132'
+http_proxy_port: '3128'
+
+commcare_errors_branch: "master-icds"
+site_locations:
+  - name: /files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: '/etc/nginx/.htpasswd'
+  - name: /bihar_ls_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
+  - name: /maharashtra_icds-cas_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
+  - name: /mp_ls_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
+  - name: /ls_hindi 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
+  - name: /ls_marathi 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
+  - name: /ls_telugu 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
+  - name: /hindi_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
+  - name: /marathi_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
+  - name: /telugu_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
+  - name: /adhaar_id_scanner_apk
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_adhaar_id_scanner_apk"
+
+couchdb_cluster_settings:
+  q: 8
+  r: 2
+  w: 2
+  n: 2
+
+couchdb2:
+  username: "{{ localsettings_private.COUCH_USERNAME }}"
+  password: "{{ localsettings_private.COUCH_PASSWORD }}"
+
+couch_dbs:
+  default:
+    host: "{{ groups.couchdb2_proxy.0 }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+localsettings:
+  ALLOWED_HOSTS:
+    - localhost
+    - 127.0.0.1
+    - '{{ SITE_HOST }}'
+    - '{{ CAS_SITE_HOST }}'
+    - '164.100.59.184'
+  ASYNC_INDICATORS_TO_QUEUE: 120000
+  ASYNC_INDICATOR_QUEUE_CRONTAB:
+    minute: '*/5'
+    hour: '0-9,16-23'
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BIGCOUCH: True
+  BIGCOUCH_QUORUM_COUNT: 2
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery0.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
+  CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
+  CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CELERY_TIMEZONE: 'Asia/Kolkata'
+  COMMCARE_HQ_NAME: 'ICDS-CAS Server'
+  COMMCARE_NAME: 'ICDS-CAS'
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_STALE_QUERY: 'update_after'
+  COUCH_MONITORING_USERNAME: "{{ localsettings_private.COUCH_MONITORING_USERNAME }}"
+  COUCH_MONITORING_PASSWORD: "{{ localsettings_private.COUCH_MONITORING_PASSWORD }}"
+  DAYS_TO_KEEP_DEVICE_LOGS: 45
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+  DROPBOX_APP_NAME: 'CommCareHQFiles'
+  DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"
+  DROPBOX_SECRET: "{{ localsettings_private.DROPBOX_SECRET }}"
+  ELASTICSEARCH_HOST: "{{ groups.es0.0 }}"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_SMTP_HOST: 'localhost'
+  EMAIL_SMTP_PORT: 25
+  EMAIL_USE_TLS: no
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  HQ_INSTANCE: 'icds'
+  HQ_PRIVATE_KEY: "{{ localsettings_private.HQ_PRIVATE_KEY }}"
+  ICDS_UCR_TEST_DATABASE_ALIAS : icds-ucr
+  ICDS_UCR_DATABASE_ALIAS: icds-ucr
+  INACTIVITY_TIMEOUT: 20160
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  KAFKA_URL: "{{ groups.kafka0.0 }}:9092"
+  LOCAL_PILLOWS:
+    icds:
+      - name: 'kafka-ucr-static-awc-location'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'location'
+          include_ucrs:
+            - 'static-awc_location'
+      - name: 'kafka-ucr-static-cases'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-hardware_cases'
+            - 'static-household_cases'
+            - 'static-tasks_cases'
+            - 'static-tech_issue_cases'
+            - 'static-child_health_cases'
+            - 'static-child_cases_monthly'
+            - 'static-child_cases_monthly_v2'
+            - 'static-child_cases_monthly_tableau_v2'
+            - 'static-ccs_record_cases'
+            - 'static-ccs_record_cases_monthly'
+            - 'static-ccs_record_cases_monthly_v2'
+            - 'static-ccs_record_cases_monthly_tableau_v2'
+            - 'static-person_cases_v2'
+      - name: 'kafka-ucr-static-forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-child_delivery_forms'
+            - 'static-daily_feeding_forms'
+            - 'static-gm_forms'
+            - 'static-home_visit_forms'
+            - 'static-infrastructure_form'
+            - 'static-awc_mgt_forms'
+            - 'static-ls_home_visit_forms_filled'
+            - 'static-thr_forms'
+            - 'static-usage_forms'
+            - 'static-vhnd_form'
+            - 'static-visitorbook_forms'
+            - 'static-it_report_follow_issue'
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "{{ hostvars[groups.pgmain.0].inventory_hostname }}"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+  PILLOWTOP_MACHINE_ID: pil0
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: True
+  REPORTING_DATABASES:
+    ucr: ucr
+    icds-ucr:
+      WRITE: icds-ucr
+      READ:
+        - [icds-ucr, 5]
+        - [icds-ucr-standby1, 5]
+    icds-test-ucr: icds-ucr
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+  SMS_GATEWAY_PARAMS:
+  SMS_GATEWAY_URL: 
+  SMS_QUEUE_ENABLED: True
+  STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"
+  STRIPE_PUBLIC_KEY: "{{ localsettings_private.STRIPE_PUBLIC_KEY }}"
+  TWO_FACTOR_SMS_GATEWAY: 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+  TWO_FACTOR_CALL_GATEWAY: 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+  USE_PARTITIONED_DATABASE: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  ENABLE_PRELOGIN_SITE: False
+  CUSTOM_LANDING_TEMPLATE: 'icds/login.html'
+  ENTERPRISE_MODE: True
+  ENABLE_DRACONIAN_SECURITY_FEATURES: yes
+  TABLEAU_URL_ROOT: "https://{{ TABLEAU_HOST }}/"
+  ICDS_DOMAIN: "{{ localsettings_private.ICDS_DOMAIN }}"

--- a/environments/icds-new/expected-public.yml
+++ b/environments/icds-new/expected-public.yml
@@ -38,6 +38,8 @@ active_sites:
   motech2: False
   riakcs: True
   cas_ssl: True
+  couchdb2: False
+  enikshay_ssl: False
 
 riak_backend: "bitcask"
 riak_ring_size: 64

--- a/environments/icds/expected-public.yml
+++ b/environments/icds/expected-public.yml
@@ -42,6 +42,8 @@ active_sites:
   motech2: False
   riakcs: True
   cas_ssl: True
+  couchdb2: False
+  enikshay_ssl: False
 
 riak_backend: "bitcask"
 riak_ring_size: 64

--- a/environments/icds/expected-public.yml
+++ b/environments/icds/expected-public.yml
@@ -1,0 +1,432 @@
+SITE_HOST: 'www.icds-cas.gov.in'
+CAS_SITE_HOST: 'cas.commcarehq.org'
+NO_WWW_SITE_HOST: 'icds-cas.gov.in'
+deploy_env: icds
+internal_domain_name: 'internal-icds.commcarehq.org'
+tableau_server: 10.247.24.11:80
+daily_deploy_email: tech-announce-daily@dimagi.com
+
+TABLEAU_HOST: 'reports.icds-cas.gov.in'
+
+nginx_combined_cert_value: "{{ ssl_secrets.certs.icds_cas_gov_in }}"
+nginx_key_value: '{{ ssl_secrets.private_keys.icds_cas_gov_in }}'
+
+cas_nginx_combined_cert_value: "{{ ssl_secrets.certs.cas_commcarehq_org }}"
+cas_key_value: '{{ ssl_secrets.private_keys.cas_commcarehq_org }}'
+
+tableau_nginx_combined_cert_value: "{{ ssl_secrets.certs.reports_icds_cas_gov_in }}"
+tableau_key_value: '{{ ssl_secrets.private_keys.reports_icds_cas_gov_in }}'
+
+static_routes:
+  - name: fastcnx
+    cmd: add
+    interface: eth0
+    prefix: "10.247.164.0/23"
+    gateway: "10.247.24.4"
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_www_redirect_insecure: True
+  cchq_http_j2me: False
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: True
+  dhis: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech1: False
+  motech2: False
+  riakcs: True
+  cas_ssl: True
+
+riak_backend: "bitcask"
+riak_ring_size: 64
+
+riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
+riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
+
+primary_ssl_env: "cas"
+nginx_max_clients: 1024
+nginx_worker_rlimit_nofile : 16384
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_cluster_name: 'prodhqes-1.x'
+
+formplayer_sentry_dsn: '{{ secrets.FORMPLAYER_SENTRY_DSN }}'
+
+supervisor_http_enabled: True
+supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"
+supervisor_http_password: "{{ secrets.SUPERVISOR_HTTP_PASSWORD }}"
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: plain
+backup_es: False
+postgres_s3: False
+backup_couch: True
+nadir_hour: 16
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_shared_buffers: '8GB'
+postgresql_max_stack_depth: '6MB'
+postgresql_effective_cache_size: '16GB'
+postgresql_max_standby_delay: '-1'
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+pg_query_stats: True
+
+formplayer_db_name: formplayer
+
+nofile_limit: 65536
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+    host: "{{ groups.postgresql.2 }}"
+  - django_alias: proxy
+    name: commcarehq_proxy
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 103]
+    host: "{{ groups.postgresql.3 }}"
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [104, 205]
+    host: "{{ groups.postgresql.3 }}"
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [206, 308]
+    host: "{{ groups.postgresql.3 }}"
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [309, 411]
+    host: "{{ groups.postgresql.3 }}"
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [412, 514]
+    host: "{{ groups.postgresql.3 }}"
+  - django_alias: p6
+    name: commcarehq_p6
+    shards: [515, 617]
+    host: "{{ groups.postgresql.1 }}"
+    query_stats: True
+  - django_alias: p7
+    name: commcarehq_p7
+    shards: [618, 720]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p8
+    name: commcarehq_p8
+    shards: [721, 823]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p9
+    name: commcarehq_p9
+    shards: [824, 926]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p10
+    name: commcarehq_p10
+    shards: [927, 1023]
+    host: "{{ groups.postgresql.1 }}"
+  - name: commcarehq_ucr
+    host: "{{ groups.postgresql.0 }}"
+    django_alias: ucr
+    django_migrate: False
+  - django_alias: icds-ucr
+    name: commcarehq_icds_aggregatedata
+    host: "{{ groups.postgresql.0 }}"
+    query_stats: True
+  - name: commcarehq_icds_testdata
+    host: "{{ groups.postgresql.0 }}"
+  - name: "{{ formplayer_db_name }}"
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: icds-ucr-standby
+    name: commcarehq_icds_aggregatedata
+    host: "{{ hostvars[groups.postgresql.0].hot_standby_server }}"
+    create: False
+    django_migrate: False
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+kafka_log_dir: '/opt/data/kafka'
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: no
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "{{ groups.rabbitmq.0 }}"
+AMQP_NAME: commcarehq
+
+ZABBIX_DB_ROOT_PASS: "{{ secrets.ZABBIX_DB_ROOT_PASS }}"
+ZABBIX_DB_USER_PASS: "{{ secrets.ZABBIX_DB_USER_PASS }}"
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+datadog_integration_cloudant: False
+datadog_integration_vmware: True
+
+file_email: False
+
+ufw_private_interface: eth0
+
+shared_drive_enabled: true
+
+# point hosts to the proxy machine
+etc_hosts_lines:
+  - '10.247.24.13		cas.commcarehq.org'
+  - '10.247.24.13		reports.icds-cas.gov.in'
+  - '10.247.24.13		www.icds-cas.gov.in'
+etc_hosts_lines_removed: []
+
+http_proxy_address: '10.247.24.16'
+http_proxy_port: '3128'
+
+commcare_errors_branch: "master-icds"
+site_locations:
+  - name: /files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: '/etc/nginx/.htpasswd'
+  - name: /bihar_ls_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_bihar"
+  - name: /maharashtra_icds-cas_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_maharashtra"
+  - name: /mp_ls_files
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_mp"
+  - name: /ls_hindi 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_hindi"
+  - name: /ls_marathi 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_marathi"
+  - name: /ls_telugu 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_ls_telugu"
+  - name: /hindi_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_hindi_files"
+  - name: /marathi_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_marathi_files"
+  - name: /telugu_files 
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_telugu_files"
+  - name: /adhaar_id_scanner_apk
+    try_files: "$uri $uri/index.html $uri/ =404"
+    auth_basic: '"Restricted Content"'
+    auth_basic_user_file: "/etc/nginx/.htpasswd_adhaar_id_scanner_apk"
+
+couchdb_cluster_settings:
+  q: 8
+  r: 2
+  w: 2
+  n: 2
+
+couchdb2:
+  username: "{{ localsettings_private.COUCH_USERNAME }}"
+  password: "{{ localsettings_private.COUCH_PASSWORD }}"
+
+couch_dbs:
+  default:
+    host: "{{ groups.couchdb2_proxy[0] }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+localsettings:
+  ALLOWED_HOSTS:
+    - localhost
+    - 127.0.0.1
+    - '{{ SITE_HOST }}'
+    - '{{ CAS_SITE_HOST }}'
+  ASYNC_INDICATORS_TO_QUEUE: 30000
+  ASYNC_INDICATOR_QUEUE_CRONTAB:
+    minute: '*/5'
+    hour: '0-7,18-23'
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BIGCOUCH: True
+  BIGCOUCH_QUORUM_COUNT: 2
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
+  CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
+  CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CELERY_TIMEZONE: 'Asia/Kolkata'
+  COMMCARE_HQ_NAME: 'ICDS-CAS Server'
+  COMMCARE_NAME: 'ICDS-CAS'
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_STALE_QUERY: 'update_after'
+  COUCH_MONITORING_USERNAME: "{{ localsettings_private.COUCH_MONITORING_USERNAME }}"
+  COUCH_MONITORING_PASSWORD: "{{ localsettings_private.COUCH_MONITORING_PASSWORD }}"
+  DAYS_TO_KEEP_DEVICE_LOGS: 45
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+  DROPBOX_APP_NAME: 'CommCareHQFiles'
+  DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"
+  DROPBOX_SECRET: "{{ localsettings_private.DROPBOX_SECRET }}"
+  ELASTICSEARCH_HOST: "{{ groups.elasticsearch.0 }}"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_SMTP_HOST: 'localhost'
+  EMAIL_SMTP_PORT: 25
+  EMAIL_USE_TLS: no
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  HQ_INSTANCE: 'icds'
+#  HUBSPOT_API_ID: "{{ localsettings_private.HUBSPOT_API_ID }}"
+#  HUBSPOT_API_KEY: "{{ localsettings_private.HUBSPOT_API_KEY }}"
+  HQ_PRIVATE_KEY: "{{ localsettings_private.HQ_PRIVATE_KEY }}"
+  ICDS_UCR_TEST_DATABASE_ALIAS : icds-ucr
+  ICDS_UCR_DATABASE_ALIAS: icds-ucr
+  INACTIVITY_TIMEOUT: 20160
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  KAFKA_URL: "{{ groups.kafka.0 }}:9092"
+  LOCAL_PILLOWS:
+    icds:
+      - name: 'kafka-ucr-static-awc-location'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'location'
+          include_ucrs:
+            - 'static-awc_location'
+      - name: 'kafka-ucr-static-cases'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'case-sql'
+          include_ucrs:
+            - 'static-hardware_cases'
+            - 'static-household_cases'
+            - 'static-tasks_cases'
+            - 'static-tech_issue_cases'
+            - 'static-child_health_cases'
+            - 'static-child_cases_monthly'
+            - 'static-child_cases_monthly_v2'
+            - 'static-child_cases_monthly_tableau_v2'
+            - 'static-ccs_record_cases'
+            - 'static-ccs_record_cases_monthly'
+            - 'static-ccs_record_cases_monthly_v2'
+            - 'static-ccs_record_cases_monthly_tableau_v2'
+            - 'static-person_cases_v2'
+      - name: 'kafka-ucr-static-forms'
+        class: 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'
+        instance: 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow'
+        params:
+          topics:
+            - 'form-sql'
+          include_ucrs:
+            - 'static-child_delivery_forms'
+            - 'static-daily_feeding_forms'
+            - 'static-gm_forms'
+            - 'static-home_visit_forms'
+            - 'static-infrastructure_form'
+            - 'static-awc_mgt_forms'
+            - 'static-ls_home_visit_forms_filled'
+            - 'static-thr_forms'
+            - 'static-usage_forms'
+            - 'static-vhnd_form'
+            - 'static-visitorbook_forms'
+            - 'static-it_report_follow_issue'
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+  PILLOWTOP_MACHINE_ID: pil0
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: True
+  REPORTING_DATABASES:
+    ucr: ucr
+    icds-ucr: icds-ucr
+    icds-test-ucr: icds-ucr
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+#  SIMPLE_API_KEYS: "{{ localsettings_private.SIMPLE_API_KEYS }}"
+  SMS_GATEWAY_PARAMS:
+  SMS_GATEWAY_URL: 
+  SMS_QUEUE_ENABLED: True
+  STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"
+  STRIPE_PUBLIC_KEY: "{{ localsettings_private.STRIPE_PUBLIC_KEY }}"
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  TWO_FACTOR_SMS_GATEWAY: 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+  TWO_FACTOR_CALL_GATEWAY: 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+  USE_PARTITIONED_DATABASE: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  XFORMS_PLAYER_URL: "http://{{ groups.touchforms.0 }}:4444/"
+  ENABLE_PRELOGIN_SITE: False
+  CUSTOM_LANDING_TEMPLATE: 'icds/login.html'
+  ENTERPRISE_MODE: True
+  ENABLE_DRACONIAN_SECURITY_FEATURES: yes
+  TABLEAU_URL_ROOT: "https://{{ TABLEAU_HOST }}/"
+  ICDS_DOMAIN: "{{ localsettings_private.ICDS_DOMAIN }}"

--- a/environments/icds/public.yml
+++ b/environments/icds/public.yml
@@ -25,10 +25,6 @@ static_routes:
     gateway: "10.247.24.4"
 
 active_sites:
-  cchq_ssl: True
-  cchq_www_redirect_secure: True
-  cchq_http: True
-  cchq_www_redirect_insecure: True
   cchq_http_j2me: False
   commtrack_ssl: False
   commtrack_http: False

--- a/environments/l10k/expected-public.yml
+++ b/environments/l10k/expected-public.yml
@@ -18,6 +18,10 @@ active_sites:
   motech: False
   motech2: False
   riakcs: False
+  cas_ssl: False
+  couchdb2: False
+  enikshay_ssl: False
+
 
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 fake_ssl_cert: no

--- a/environments/l10k/expected-public.yml
+++ b/environments/l10k/expected-public.yml
@@ -1,0 +1,206 @@
+SITE_HOST: 'l10k.commcarehq.org'
+COMMTRACK_SITE_HOST: 'l10k.commcarehq.org'
+NO_WWW_SITE_HOST: 'l10k.commcarehq.org'
+deploy_env: l10k
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_http_j2me: False
+  cchq_www_redirect_insecure: False
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech2: False
+  riakcs: False
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+NEW_RELIC_KEY: "{{ secrets.NEW_RELIC_KEY }}"
+run_newrelic_plugin_agent: False
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_memory: '4096m'
+elasticsearch_cluster_name: 'l10k-es'
+#elasticsearch_node_name: '??'
+
+nginx_key_file: '../config/{{ deploy_env }}/ssl/l10k.commcarehq.org.key'
+nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/l10k.commcarehq.org.combined.crt'
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: False
+backup_es: False
+backup_couch: False
+postgres_s3: False
+blobdb_s3: False
+couch_s3: False
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgres_config:
+  max_connections: 300
+  pgb_max_connections: 400
+  pgb_default_pool: 290
+  pgb_reserve_pool: 5
+  pgb_pool_timeout: 1
+  pgb_pool_mode: transaction
+
+formplayer_db_name: formplayer
+
+postgresql_dbs:
+  - name: commcarehq_ucr
+    django_alias: ucr
+  - name: "{{ localsettings.PG_DATABASE_NAME }}"
+    django_alias: default
+  - name: "{{ formplayer_db_name }}"
+
+couchdb2:
+  username: "{{ localsettings_private.COUCH_USERNAME }}"
+  password: "{{ localsettings_private.COUCH_PASSWORD }}"
+
+couchdb_cluster_settings:
+  q: 8
+  r: 1
+  w: 1
+  n: 1
+
+couch_dbs:
+  default:
+    host: "{{ groups.couchdb2_proxy[0] }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "192.168.0.10"
+AMQP_NAME: commcarehq
+
+shared_drive_enabled: false
+
+localsettings:
+  ALLOWED_HOSTS:
+    - l10k.commcarehq.org
+    - 192.168.0.10
+    - localhost
+    - 127.0.0.1
+    - testserver
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
+  CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CLOUDCARE_BASE_URL: http://localhost:9010
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_DATABASE_NAME: "{{ localsettings_private.COUCH_DATABASE_NAME }}"
+  COUCH_HTTPS: False
+  COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
+  COUCH_SERVER_ROOT: "192.168.0.10"
+  COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
+  COUCH_PORT: 5984
+# l10k is not hosted by Cloudant
+  COUCH_STALE_QUERY: 'update_after'
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+#  DROPBOX_APP_NAME:
+#  DROPBOX_KEY:
+#  DROPBOX_SECRET:
+  ELASTICSEARCH_HOST: "localhost"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_SMTP_HOST: 'localhost'
+  EMAIL_SMTP_PORT: 25
+  EMAIL_USE_TLS: no
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  HQ_INSTANCE: 'l10k'
+  HUBSPOT_API_ID:
+  HUBSPOT_API_KEY:
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: ''
+#  KAFKA_HOST:
+  KISSMETRICS_KEY:
+  MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "127.0.0.1"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+#  PILLOWTOP_MACHINE_ID:
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "localhost"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: False
+  REPORTING_DATABASES:
+    ucr: ucr
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SIMPLE_API_KEYS:
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+  SMS_GATEWAY_PARAMS: "{{ localsettings_private.SMS_GATEWAY_PARAMS }}"
+  SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
+  SMS_QUEUE_ENABLED: False
+#  STATIC_ROOT:
+#  STRIPE_PRIVATE_KEY:
+#  STRIPE_PUBLIC_KEY:
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  XFORMS_PLAYER_URL: "http://127.0.0.1:4444/"

--- a/environments/pna/expected-public.yml
+++ b/environments/pna/expected-public.yml
@@ -1,0 +1,276 @@
+SITE_HOST: 'commcare.pna.sn'
+PNA_SITE_HOST: 'pna.commcarehq.org'
+COMMTRACK_SITE_HOST: 'commcare.pna.sn'
+deploy_env: pna
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: False
+  cchq_http: True
+  cchq_http_j2me: False
+  cchq_www_redirect_insecure: False
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech2: False
+  riakcs: False
+  pna_ssl: True
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+ssh_port: 1337
+fake_ssl_cert: no
+
+#NEW_RELIC_KEY: "{{ secrets.NEW_RELIC_KEY }}"
+#run_newrelic_plugin_agent: False
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_memory: '2048m'
+elasticsearch_cluster_name: 'pna-es'
+#elasticsearch_node_name: '??'
+
+nginx_key_file: '../config/{{ deploy_env }}/ssl/commcare.pna.sn.key'
+nginx_key_value: '{{ ssl_secrets.private_keys.commcare_pna_sn }}'
+nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/commcare.pna.sn.combined.crt'
+nginx_combined_cert_value: "{{ ssl_secrets.certs.commcare_pna_sn }}"
+
+pna_nginx_combined_cert_file: '../config/{{ deploy_env}}/ssl/pna.commcarehq.org.combined.crt'
+pna_nginx_combined_cert_value: '{{ ssl_secrets.certs.pna_commcarehq_org }}'
+pna_key_file: '../config/{{ deploy_env }}/ssl/pna.commcarehq.org.key'
+pna_key_value: '{{ ssl_secrets.private_keys.pna_commcarehq_org }}'
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: True
+backup_postgres: dump
+backup_es: True
+backup_couch: True
+postgres_s3: True
+blobdb_s3: True
+couch_s3: True
+
+aws_region: 'us-east-1'
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_shared_buffers: '2GB'
+postgresql_max_stack_depth: '4MB'
+postgresql_effective_cache_size: '8GB'
+postgresql_max_connections: 300
+pgbouncer_max_connections: 400
+pgbouncer_default_pool: 290
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+pg_query_stats: False
+
+formplayer_db_name: formplayer
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: proxy
+    name: commcarehq_proxy
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 103]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [104, 205]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [206, 308]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [309, 411]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [412, 514]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p6
+    name: commcarehq_p6
+    shards: [515, 617]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p7
+    name: commcarehq_p7
+    shards: [618, 720]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p8
+    name: commcarehq_p8
+    shards: [721, 823]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p9
+    name: commcarehq_p9
+    shards: [824, 926]
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: p10
+    name: commcarehq_p10
+    shards: [927, 1023]
+    host: "{{ groups.postgresql.0 }}"
+  - name: commcarehq_ucr
+    query_stats: True
+    host: "{{ groups.postgresql.0 }}"
+    django_alias: ucr
+    django_migrate: False
+  - name: "{{ formplayer_db_name }}"
+    host: "{{ groups.postgresql.0 }}"
+
+
+couchdb2:
+  username: "{{ localsettings_private.COUCH_USERNAME }}"
+  password: "{{ localsettings_private.COUCH_PASSWORD }}"
+
+couchdb_cluster_settings:
+  q: 8
+  r: 1
+  w: 1
+  n: 1
+
+couch_dbs:
+  default:
+    host: 127.0.0.1
+    port: 25984
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+server_email: commcare@pna.sn
+default_from_email: commcare@pna.sn
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "127.0.0.1"
+AMQP_NAME: commcarehq
+
+shared_drive_enabled: false
+
+localsettings:
+  ALLOWED_HOSTS:
+    - "{{ PNA_SITE_HOST }}"
+    - "{{ SITE_HOST }}"
+    - localhost
+    - 127.0.0.1
+  AMAZON_S3_ACCESS_KEY: "{{ localsettings_private.AMAZON_S3_ACCESS_KEY }}"
+  AMAZON_S3_SECRET_KEY: "{{ localsettings_private.AMAZON_S3_SECRET_KEY }}"
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
+  CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CLOUDCARE_BASE_URL: http://localhost:9010
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_DATABASE_NAME: "{{ localsettings_private.COUCH_DATABASE_NAME }}"
+  COUCH_HTTPS: False
+  COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
+  COUCH_SERVER_ROOT: "127.0.0.1"
+  COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
+  COUCH_PORT: 5984
+# pna is not hosted by Cloudant
+  COUCH_STALE_QUERY: 'update_after'
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+#  DROPBOX_APP_NAME:
+#  DROPBOX_KEY:
+#  DROPBOX_SECRET:
+  ELASTICSEARCH_HOST: "localhost"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_SMTP_HOST: 'localhost'
+  EMAIL_SMTP_PORT: 25
+  EMAIL_USE_TLS: no
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  HQ_INSTANCE: 'pna'
+  HUBSPOT_API_ID:
+  HUBSPOT_API_KEY:
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: ''
+#  KAFKA_HOST:
+  KISSMETRICS_KEY:
+  MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "127.0.0.1"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+#  PILLOWTOP_MACHINE_ID:
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "localhost"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: False
+  REPORTING_DATABASES:
+    ucr: ucr
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SIMPLE_API_KEYS:
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+  SMS_GATEWAY_PARAMS: "{{ localsettings_private.SMS_GATEWAY_PARAMS }}"
+  SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
+  SMS_QUEUE_ENABLED: False
+#  STATIC_ROOT:
+#  STRIPE_PRIVATE_KEY:
+#  STRIPE_PUBLIC_KEY:
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  USE_PARTITIONED_DATABASE: True
+  XFORMS_PLAYER_URL: "http://127.0.0.1:4444/"
+  ENABLE_PRELOGIN_SITE: False
+  ENTERPRISE_MODE: True

--- a/environments/pna/expected-public.yml
+++ b/environments/pna/expected-public.yml
@@ -19,6 +19,9 @@ active_sites:
   motech2: False
   riakcs: False
   pna_ssl: True
+  cas_ssl: False
+  couchdb2: False
+  enikshay_ssl: False
 
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 ssh_port: 1337

--- a/environments/pna/public.yml
+++ b/environments/pna/public.yml
@@ -4,20 +4,9 @@ COMMTRACK_SITE_HOST: 'commcare.pna.sn'
 deploy_env: pna
 
 active_sites:
-  cchq_ssl: True
   cchq_www_redirect_secure: False
-  cchq_http: True
   cchq_http_j2me: False
   cchq_www_redirect_insecure: False
-  commtrack_ssl: False
-  commtrack_http: False
-  tableau: False
-  icds_tableau: False
-  wiki: False
-  wiki_http: False
-  motech: False
-  motech2: False
-  riakcs: False
   pna_ssl: True
 
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"

--- a/environments/production/expected-public.yml
+++ b/environments/production/expected-public.yml
@@ -1,0 +1,273 @@
+SITE_HOST: 'www.commcarehq.org'
+NO_WWW_SITE_HOST: 'commcarehq.org'
+COMMTRACK_SITE_HOST: 'commtrack.org'
+J2ME_SITE_HOST: 'j2mewww.commcarehq.org'
+deploy_env: production
+daily_deploy_email: tech-announce-daily@dimagi.com
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_www_redirect_insecure: True
+  cchq_http_j2me: True
+  commtrack_ssl: True
+  commtrack_http: True
+  tableau: True
+  icds_tableau: False
+  wiki: True
+  wiki_http: True
+  motech: True
+  motech2: True
+  riakcs: True
+  cas_ssl: False
+  couchdb2: False
+
+riak_backend: "leveldb-bad-config"
+riak_ring_size: 64
+riak_new_backend: "leveldb"
+riak_new_ring_size: 128
+
+riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
+riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
+old_s3_blob_db_access_key: "{{ secrets.OLD_S3_BLOB_DB_ACCESS_KEY }}"
+old_s3_blob_db_secret_key: "{{ secrets.OLD_S3_BLOB_DB_SECRET_KEY }}"
+
+# This sets production_commcare as the default endpoint for ssl connections
+primary_ssl_env: "production"
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+NEW_RELIC_KEY: "{{ secrets.NEW_RELIC_KEY }}"
+run_newrelic_plugin_agent: True
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+CLOUDANT_CLUSTER_NAME: dimagi003
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_cluster_name: 'prodhqes-1.x'
+#elasticsearch_memory: '4096m'
+#elasticsearch_node_name: '???'
+
+formplayer_sentry_dsn: '{{ secrets.FORMPLAYER_SENTRY_DSN }}'
+
+nofile_limit: 65536
+
+# commcarehq.org of certs
+nginx_combined_cert_value: "{{ ssl_secrets.certs.commcarehq_org }}"
+nginx_key_value: '{{ ssl_secrets.private_keys.commcarehq_org }}'
+
+# commtrack.org
+commtrack_nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/commtrack.org.combined.crt'
+commtrack_key_file: '../config/{{ deploy_env }}/ssl/commtrack.org.key'
+
+supervisor_http_enabled: True
+supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"
+supervisor_http_password: "{{ secrets.SUPERVISOR_HTTP_PASSWORD }}"
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: plain
+backup_es: True
+postgres_s3: True
+
+aws_region: 'us-east-1'
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_max_connections: 300
+pgbouncer_max_connections: 800
+pgbouncer_default_pool: 290
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+pg_query_stats: True
+
+formplayer_db_name: formplayer
+formplayer_archive_time_spec: '10m'
+formplayer_purge_time_spec: '8d'
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+    host: "{{ groups.postgresql.0 }}"
+  - django_alias: proxy
+    name: commcarehq_proxy
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 204]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [205, 409]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [410, 614]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [615, 819]
+    host: "{{ groups.postgresql.1 }}"
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [820, 1023]
+    host: "{{ groups.postgresql.1 }}"
+  - name: commcarehq_ucr
+    host: "{{ groups.postgresql.0 }}"
+    query_stats: True
+    django_alias: ucr
+    django_migrate: False
+  - name: "{{ formplayer_db_name }}"
+    host: "{{ groups.postgresql.0 }}"
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "{{ groups.rabbitmq.0 }}"
+AMQP_NAME: commcarehq
+
+ufw_private_interface: eth1
+
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
+
+couch_dbs:
+  default:
+    host: commcarehq.cloudant.com
+    port: 443
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: True
+
+localsettings:
+  ALLOWED_HOSTS:
+    - www.commcarehq.org
+    - www.commtrack.org
+    - localhost
+    - 127.0.0.1
+    - testserver
+    - proxytest.commcarehq.org
+    - "{{ J2ME_SITE_HOST }}"
+  ANALYTICS_DEBUG: False
+  ANALYTICS_LOG_LEVEL: "warning"
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BLOB_DB_MIGRATING_FROM_S3_TO_S3: True
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
+  CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
+  CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_MONITORING_USERNAME: "{{ localsettings_private.COUCH_MONITORING_USERNAME }}"
+  COUCH_MONITORING_PASSWORD: "{{ localsettings_private.COUCH_MONITORING_PASSWORD }}"
+  CUSTOM_SYNCLOGS_DB: "synclogs_2017-11-01"
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+  DROPBOX_APP_NAME: 'CommCareHQFiles'
+  DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"
+  DROPBOX_SECRET: "{{ localsettings_private.DROPBOX_SECRET }}"
+  ELASTICSEARCH_HOST: "{{ groups.elasticsearch.0 }}"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_PASSWORD: "{{ localsettings_private.EMAIL_PASSWORD }}"
+  EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
+  EMAIL_SMTP_PORT: 587
+  EMAIL_USE_TLS: yes
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  FULLSTORY_ID: "{{ localsettings_private.FULLSTORY_ID }}"
+  GREENHOUSE_API_KEY: "{{ localsettings_private.GREENHOUSE_API_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  DRIFT_ID: "{{ localsettings_private.DRIFT_ID }}"
+  HQ_INSTANCE: 'www'
+  HUBSPOT_API_ID: "{{ localsettings_private.HUBSPOT_API_ID }}"
+  HUBSPOT_API_KEY: "{{ localsettings_private.HUBSPOT_API_KEY }}"
+  HQ_PRIVATE_KEY: "{{ localsettings_private.HQ_PRIVATE_KEY }}"
+  INACTIVITY_TIMEOUT: 20160
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
+  KAFKA_URL: "{{ groups.kafka.0 }}:9092"
+  KISSMETRICS_KEY: "{{ localsettings_private.KISSMETRICS_KEY }}"
+  MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  MOBILE_INTEGRATION_TEST_TOKEN: "{{ localsettings_private.MOBILE_INTEGRATION_TEST_TOKEN }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+  PILLOWTOP_MACHINE_ID: hqdb0
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: True
+  REPORTING_DATABASES:
+    ucr: ucr
+  AMAZON_S3_ACCESS_KEY: "{{ localsettings_private.AMAZON_S3_ACCESS_KEY }}"
+  AMAZON_S3_SECRET_KEY: "{{ localsettings_private.AMAZON_S3_SECRET_KEY }}"
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+  SIMPLE_API_KEYS: "{{ localsettings_private.SIMPLE_API_KEYS }}"
+  SMS_GATEWAY_PARAMS: "{{ localsettings_private.SMS_GATEWAY_PARAMS }}"
+  SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
+  SMS_QUEUE_ENABLED: True
+  STATIC_ROOT:
+  STATIC_CDN: 'https://dnwn0mt1jqwp0.cloudfront.net'
+  STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"
+  STRIPE_PUBLIC_KEY: "{{ localsettings_private.STRIPE_PUBLIC_KEY }}"
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  TWO_FACTOR_SMS_GATEWAY: 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+  TWO_FACTOR_CALL_GATEWAY: 'corehq.apps.hqwebapp.two_factor_gateways.Gateway'
+  USE_PARTITIONED_DATABASE: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  XFORMS_PLAYER_URL: "http://{{ groups.touchforms.0 }}:4444/"

--- a/environments/production/expected-public.yml
+++ b/environments/production/expected-public.yml
@@ -22,6 +22,7 @@ active_sites:
   riakcs: True
   cas_ssl: False
   couchdb2: False
+  enikshay_ssl: False
 
 riak_backend: "leveldb-bad-config"
 riak_ring_size: 64

--- a/environments/production/public.yml
+++ b/environments/production/public.yml
@@ -6,22 +6,14 @@ deploy_env: production
 daily_deploy_email: tech-announce-daily@dimagi.com
 
 active_sites:
-  cchq_ssl: True
-  cchq_www_redirect_secure: True
-  cchq_http: True
-  cchq_www_redirect_insecure: True
-  cchq_http_j2me: True
   commtrack_ssl: True
   commtrack_http: True
   tableau: True
-  icds_tableau: False
   wiki: True
   wiki_http: True
   motech: True
   motech2: True
   riakcs: True
-  cas_ssl: False
-  couchdb2: False
 
 riak_backend: "leveldb-bad-config"
 riak_ring_size: 64

--- a/environments/softlayer/expected-public.yml
+++ b/environments/softlayer/expected-public.yml
@@ -1,0 +1,288 @@
+SITE_HOST: 'india.commcarehq.org'
+CAS_SITE_HOST: 'cas.commcarehq.org'
+ENIKSHAY_SITE_HOST: 'enikshay.commcarehq.org'
+J2ME_SITE_HOST: 'j2me-india.commcarehq.org'
+deploy_env: softlayer
+tableau_server: 'tableau2.internal.commcarehq.org'
+TABLEAU_HOST: 'icds.commcarehq.org'
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: False
+  cchq_http: True
+  cchq_www_redirect_insecure: False
+  cchq_http_j2me: True
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech2: False
+  riakcs: True
+  cas_ssl: False
+  enikshay_ssl: False
+
+couchdb2:
+  username: "{{ localsettings_private.COUCH_USERNAME }}"
+  password: "{{ localsettings_private.COUCH_PASSWORD }}"
+
+riak_backend: "leveldb"
+riak_ring_size: 128
+
+riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
+riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
+old_s3_blob_db_access_key: "{{ secrets.OLD_S3_BLOB_DB_ACCESS_KEY }}"
+old_s3_blob_db_secret_key: "{{ secrets.OLD_S3_BLOB_DB_SECRET_KEY }}"
+
+primary_ssl_env: "softlayer"
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+NEW_RELIC_KEY: "{{ secrets.NEW_RELIC_KEY }}"
+run_newrelic_plugin_agent: False
+
+DATADOG_ENABLED: True
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_memory: '8192m'
+elasticsearch_cluster_name: 'indiahqes-1.x'
+
+nginx_key_file: '../config/{{ deploy_env }}/ssl/india.commcarehq.org.key'
+# Nginx only accepts on cert, so cat the site cert and chain:
+# $ cat india.commcarehq.org.crt intermediate.crt > india.commcarehq.org.combined.crt
+nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/india.commcarehq.org.combined.crt'
+
+
+tableau_nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/icds.commcarehq.org.combined.crt'
+tableau_key_file: '../config/{{ deploy_env }}/ssl/icds.commcarehq.org.key'
+
+cas_nginx_combined_cert_file: '../config/{{ deploy_env}}/ssl/cas.commcarehq.org.combined.crt'
+cas_key_file: '../config/{{ deploy_env }}/ssl/cas.commcarehq.org.key'
+
+enikshay_nginx_combined_cert_file: '../config/{{ deploy_env}}/ssl/enikshay.commcarehq.org.combined.crt'
+enikshay_key_file: '../config/{{ deploy_env }}/ssl/enikshay.commcarehq.org.key'
+
+formplayer_sentry_dsn: '{{ secrets.FORMPLAYER_SENTRY_DSN }}'
+
+supervisor_http_enabled: True
+supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"
+supervisor_http_password: "{{ secrets.SUPERVISOR_HTTP_PASSWORD }}"
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: plain
+backup_es: True
+postgres_s3: True
+
+aws_region: 'ap-south-1'
+
+nofile_limit: 65536
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_max_connections: 300
+pgbouncer_max_connections: 1000
+pgbouncer_default_pool: 290
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+
+formplayer_db_name: formplayer
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+  - django_alias: proxy
+    name: commcarehq_proxy
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 204]
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [205, 409]
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [410, 614]
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [615, 819]
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [820, 1023]
+  - name: commcarehq_ucr
+    django_alias: ucr
+  - django_alias: icds-ucr
+    name: icds-ucr
+  - name: "{{ formplayer_db_name }}"
+  - name: commcarehq_icds_testdata
+
+postgresql_ssl_enabled: False
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "{{ groups.rabbitmq.0 }}"
+AMQP_NAME: commcarehq
+
+kafka_broker_id: 0
+kafka_log_dir: '/opt/data/kafka'
+
+encrypted_root: /opt/data/ecrypt
+
+ufw_private_interface: eth0
+
+control_machine_ip: 10.162.36.196
+
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
+
+shared_drive_enabled: true
+
+
+couch_dbs:
+  default:
+    host: "{{ groups.couchdb2_proxy[0] }}"
+    port: "{{ couchdb2_proxy_port }}"
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+
+couchdb_cluster_settings:
+  q: 8
+  r: 1
+  w: 1
+  n: 1
+
+
+localsettings:
+  ALLOWED_HOSTS:
+    - localhost
+    - 127.0.0.1
+    - "{{ CAS_SITE_HOST }}"
+    - "{{ ENIKSHAY_SITE_HOST }}"
+    - "{{ SITE_HOST }}"
+    - "{{ J2ME_SITE_HOST }}"
+  ASYNC_INDICATORS_TO_QUEUE: 30000
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.1 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: 'reminder_case_update_queue'
+  CELERY_REMINDER_RULE_QUEUE: 'reminder_rule_queue'
+  CELERY_REPEAT_RECORD_QUEUE: 'repeat_record_queue'
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+#  COUCH_CACHE_DOCS:
+#  COUCH_CACHE_VIEWS:
+  COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
+  COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
+  DEPLOY_MACHINE_NAME: "{{ inventory_hostname }}"
+  DROPBOX_APP_NAME: 'CommCareHQFiles'
+  DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"
+  DROPBOX_SECRET: "{{ localsettings_private.DROPBOX_SECRET }}"
+  ELASTICSEARCH_HOST: "{{ groups.elasticsearch.0 }}"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_PASSWORD: "{{ localsettings_private.EMAIL_PASSWORD }}"
+  EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
+  EMAIL_SMTP_PORT: 587
+  EMAIL_USE_TLS: yes
+  ENABLE_DRACONIAN_SECURITY_FEATURES: yes
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: '{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}'
+  DRIFT_ID: "{{ localsettings_private.DRIFT_ID }}"
+  HQ_INSTANCE: 'india'
+  HQ_PRIVATE_KEY: "{{ localsettings_private.HQ_PRIVATE_KEY }}"
+  HUBSPOT_API_ID: '{{ localsettings_private.HUBSPOT_API_ID }}'
+  HUBSPOT_API_KEY: '{{ localsettings_private.HUBSPOT_API_KEY }}'
+  ICDS_UCR_DATABASE_ALIAS: icds-ucr
+  ICDS_UCR_TEST_DATABASE_ALIAS : icds-ucr
+  INACTIVITY_TIMEOUT: 20160
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: India-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
+  KAFKA_URL: "{{ groups.kafka.0 }}"
+  KISSMETRICS_KEY: "{{ localsettings_private.KISSMETRICS_KEY }}"
+#  MAPS_LAYERS:
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+  PILLOWTOP_MACHINE_ID: indiacloud
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: True
+  REPORTING_DATABASES:
+    ucr: ucr
+    icds-ucr: icds-ucr
+    icds-test-ucr: icds-ucr
+  AMAZON_S3_ACCESS_KEY: "{{ localsettings_private.AMAZON_S3_ACCESS_KEY }}"
+  AMAZON_S3_SECRET_KEY: "{{ localsettings_private.AMAZON_S3_SECRET_KEY }}"
+  SAVED_EXPORT_ACCESS_CUTOFF: 180
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+#  SIMPLE_API_KEYS:
+  SMS_GATEWAY_PARAMS:
+  SMS_GATEWAY_URL: ''
+  SMS_QUEUE_ENABLED: True
+#  STATIC_ROOT:
+  STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"
+  STRIPE_PUBLIC_KEY: "{{ localsettings_private.STRIPE_PUBLIC_KEY }}"
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  TRANSFER_SERVER: 'nginx'
+  USE_PARTITIONED_DATABASE: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  XFORMS_PLAYER_URL: "http://{{ groups.touchforms.0 }}:4444/"
+  ENIKSHAY_PRIVATE_API_USERS: {'BI': 'ppia-bi21', 'GU': 'ppia-gu21', 'MH': 'ppia-mh14'}
+  ENIKSHAY_PRIVATE_API_PASSWORD: "{{ localsettings_private.ENIKSHAY_PRIVATE_API_PASSWORD }}"

--- a/environments/softlayer/expected-public.yml
+++ b/environments/softlayer/expected-public.yml
@@ -23,6 +23,7 @@ active_sites:
   riakcs: True
   cas_ssl: False
   enikshay_ssl: False
+  couchdb2: False
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"

--- a/environments/softlayer/public.yml
+++ b/environments/softlayer/public.yml
@@ -7,22 +7,9 @@ tableau_server: 'tableau2.internal.commcarehq.org'
 TABLEAU_HOST: 'icds.commcarehq.org'
 
 active_sites:
-  cchq_ssl: True
-  cchq_www_redirect_secure: False
-  cchq_http: True
-  cchq_www_redirect_insecure: False
-  cchq_http_j2me: True
-  commtrack_ssl: False
-  commtrack_http: False
-  tableau: False
-  icds_tableau: False
-  wiki: False
-  wiki_http: False
-  motech: False
-  motech2: False
   riakcs: True
-  cas_ssl: False
-  enikshay_ssl: False
+  cchq_www_redirect_insecure: false
+  cchq_www_redirect_secure: false
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"

--- a/environments/staging/expected-public.yml
+++ b/environments/staging/expected-public.yml
@@ -1,0 +1,235 @@
+SITE_HOST: 'staging.commcarehq.org'
+NO_WWW_SITE_HOST: 'staging.commcarehq.org'
+COMMTRACK_SITE_HOST: 'test.commtrack.org'
+J2ME_SITE_HOST: 'j2mestaging.commcarehq.org'
+deploy_env: staging
+
+active_sites:
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_www_redirect_insecure: True
+  cchq_http_j2me: True
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  motech: False
+  motech2: False
+  riakcs: True
+  couchdb2: False
+
+riak_backend: "leveldb"
+riak_ring_size: 64
+
+riakcs_s3_access_key: "{{ secrets.RIAKCS_S3_ACCESS_KEY }}"
+riakcs_s3_secret_key: "{{ secrets.RIAKCS_S3_SECRET_KEY }}"
+
+primary_ssl_env: "staging"
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+NEW_RELIC_KEY: "{{ secrets.NEW_RELIC_KEY }}"
+run_newrelic_plugin_agent: False
+
+DATADOG_ENABLED: False
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_cluster_name: 'staginges'
+
+# Source paths of certs
+nginx_key_file: '../config/{{ deploy_env }}/ssl/commcarehq.org.key'
+# Nginx only accepts on cert, so cat the site cert and chain:
+# $ cat commcarehq.org.crt hq_thawtecabundle.crt > commcarehq.org.combined.crt
+nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/commcarehq.org.combined.crt'
+
+# Commtrack Certs
+commtrack_nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/commtrack.org.combined.crt'
+commtrack_key_file: '../config/{{ deploy_env }}/ssl/commtrack.org.key'
+
+supervisor_http_enabled: True
+supervisor_http_username: "{{ secrets.SUPERVISOR_HTTP_USERNAME }}"
+supervisor_http_password: "{{ secrets.SUPERVISOR_HTTP_PASSWORD }}"
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: plain
+backup_es: False
+postgres_s3: False
+
+aws_region: 'us-east-1'
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_max_connections: 20
+pgbouncer_max_connections: 100
+pgbouncer_default_pool: 15
+pgbouncer_reserve_pool: 4
+pgbouncer_pool_timeout: 2
+pgbouncer_pool_mode: transaction
+pg_query_stats: True
+
+formplayer_db_name: formplayer
+formplayer_archive_time_spec: '10m'
+
+postgresql_dbs:
+  - django_alias: default
+    name: "{{localsettings.PG_DATABASE_NAME}}"
+    query_stats: True
+  - django_alias: proxy
+    name: commcarehq_proxy
+  - django_alias: p1
+    name: commcarehq_p1
+    shards: [0, 99]
+    query_stats: True
+  - django_alias: p2
+    name: commcarehq_p2
+    shards: [100, 199]
+    query_stats: True
+  - django_alias: p3
+    name: commcarehq_p3
+    shards: [200, 299]
+    query_stats: True
+  - django_alias: p4
+    name: commcarehq_p4
+    shards: [300, 399]
+    query_stats: True
+  - django_alias: p5
+    name: commcarehq_p5
+    shards: [400, 511]
+    query_stats: True
+  - name: commcarehq_ucr
+    query_stats: True
+    django_alias: ucr
+    django_migrate: False
+  - name: "{{ formplayer_db_name }}"
+  - django_alias: icds-ucr
+    name: commcarehq_icds_testdata
+    query_stats: True
+    django_migrate: False
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "{{ groups.rabbitmq.0 }}"
+AMQP_NAME: commcarehq
+
+ufw_private_interface: eth1
+
+etc_hosts_lines: []
+etc_hosts_lines_removed: []
+
+
+couch_dbs:
+  default:
+    host: commcarehq.cloudant.com
+    port: 443
+    name: staging_commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: True
+
+localsettings:
+  ALLOWED_HOSTS:
+    - staging.commcarehq.org
+    - j2mestaging.commcarehq.org
+    - localhost
+    - 127.0.0.1
+    - testserver
+  ANALYTICS_DEBUG: False
+  ANALYTICS_LOG_LEVEL: "debug"
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_null'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE:
+  CELERY_REMINDER_RULE_QUEUE:
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
+  COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+  DROPBOX_APP_NAME: 'CommCareHQFiles - Staging'
+  DROPBOX_KEY: "{{ localsettings_private.DROPBOX_KEY }}"
+  DROPBOX_SECRET: "{{ localsettings_private.DROPBOX_SECRET }}"
+  ELASTICSEARCH_HOST: "{{ groups.elasticsearch.0 }}"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_PASSWORD: "{{ localsettings_private.EMAIL_PASSWORD }}"
+  EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
+  EMAIL_SMTP_PORT: 587
+  EMAIL_USE_TLS: yes
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  HQ_INSTANCE: 'staging'
+  HUBSPOT_API_ID: "{{ localsettings_private.HUBSPOT_API_ID }}"
+  HUBSPOT_API_KEY: "{{ localsettings_private.HUBSPOT_API_KEY }}"
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: "{{ J2ME_SITE_HOST }}"
+  KAFKA_URL: "{{ groups.kafka.0 }}:9092"
+  KISSMETRICS_KEY: "{{ localsettings_private.KISSMETRICS_KEY }}"
+  MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "{{ groups.postgresql.0 }}"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+  PILLOWTOP_MACHINE_ID: staging-hqdb0-ubuntu
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "{{ groups.redis.0 }}"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: False
+  REPORTING_DATABASES:
+    ucr: ucr
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+  SIMPLE_API_KEYS:
+  SMS_GATEWAY_PARAMS: "{{ localsettings_private.SMS_GATEWAY_PARAMS }}"
+  SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
+  SMS_QUEUE_ENABLED: True
+  STATIC_ROOT:
+  STATIC_CDN: 'https://d2f60qxn5rwjxl.cloudfront.net'
+  STRIPE_PRIVATE_KEY: "{{ localsettings_private.STRIPE_PRIVATE_KEY }}"
+  STRIPE_PUBLIC_KEY: "{{ localsettings_private.STRIPE_PUBLIC_KEY }}"
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  USE_PARTITIONED_DATABASE: True
+  WS4REDIS_CONNECTION_HOST: "{{ groups.redis.0 }}"
+  XFORMS_PLAYER_URL: "http://{{ groups.touchforms.0 }}:4444/"

--- a/environments/staging/expected-public.yml
+++ b/environments/staging/expected-public.yml
@@ -7,6 +7,7 @@ deploy_env: staging
 active_sites:
   cchq_www_redirect_secure: True
   cchq_http: True
+  cchq_ssl: False
   cchq_www_redirect_insecure: True
   cchq_http_j2me: True
   commtrack_ssl: False
@@ -14,10 +15,13 @@ active_sites:
   tableau: False
   icds_tableau: False
   wiki: False
+  wiki_http: False
   motech: False
   motech2: False
   riakcs: True
   couchdb2: False
+  cas_ssl: False
+  enikshay_ssl: False
 
 riak_backend: "leveldb"
 riak_ring_size: 64

--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -7,6 +7,7 @@ deploy_env: staging
 active_sites:
   cchq_www_redirect_secure: True
   cchq_http: True
+  cchq_ssl: False
   cchq_www_redirect_insecure: True
   cchq_http_j2me: True
   commtrack_ssl: False
@@ -14,6 +15,7 @@ active_sites:
   tableau: False
   icds_tableau: False
   wiki: False
+  wiki_http: False
   motech: False
   motech2: False
   riakcs: True

--- a/environments/swiss/expected-public.yml
+++ b/environments/swiss/expected-public.yml
@@ -19,6 +19,8 @@ active_sites:
   motech2: False
   riakcs: False
   couchdb2: False
+  cas_ssl: False
+  enikshay_ssl: False
 
 ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
 fake_ssl_cert: no

--- a/environments/swiss/expected-public.yml
+++ b/environments/swiss/expected-public.yml
@@ -1,0 +1,195 @@
+SITE_HOST: 'swiss.commcarehq.org'
+COMMTRACK_SITE_HOST: 'swiss.commcarehq.org'
+NO_WWW_SITE_HOST: 'swiss.commcarehq.org'
+deploy_env: swiss
+
+active_sites:
+  cchq_ssl: True
+  cchq_www_redirect_secure: True
+  cchq_http: True
+  cchq_http_j2me: False
+  cchq_www_redirect_insecure: False
+  commtrack_ssl: False
+  commtrack_http: False
+  tableau: False
+  icds_tableau: False
+  wiki: False
+  wiki_http: False
+  motech: False
+  motech2: False
+  riakcs: False
+  couchdb2: False
+
+ansible_user_password_sha_512: "{{ secrets.ANSIBLE_USER_PASSWORD_SHA_512 }}"
+fake_ssl_cert: no
+
+NEW_RELIC_KEY: "{{ secrets.NEW_RELIC_KEY }}"
+run_newrelic_plugin_agent: False
+
+DATADOG_ENABLED: True
+DATADOG_INTEGRATIONS_ENABLED: False
+DATADOG_API_KEY: "{{ secrets.DATADOG_API_KEY }}"
+DATADOG_APP_KEY: "{{ secrets.DATADOG_APP_KEY }}"
+
+elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
+elasticsearch_memory: '4096m'
+elasticsearch_cluster_name: 'deves'
+#elasticsearch_node_name: '??'
+
+nginx_key_file: '../config/{{ deploy_env }}/ssl/swiss.commcarehq.org.key'
+nginx_combined_cert_file: '../config/{{ deploy_env }}/ssl/swiss.commcarehq.org.combined.crt'
+
+keystore_file: '../config/DimagiKeyStore'
+
+backup_blobdb: False
+backup_postgres: False
+backup_es: False
+backup_couch: False
+postgres_s3: False
+blobdb_s3: False
+couch_s3: False
+
+postgres_users: "{{ secrets.POSTGRES_USERS }}"
+
+postgresql_max_connections: 300
+pgbouncer_max_connections: 400
+pgbouncer_default_pool: 290
+pgbouncer_reserve_pool: 5
+pgbouncer_pool_timeout: 1
+pgbouncer_pool_mode: transaction
+
+formplayer_db_name: formplayer
+
+postgresql_dbs:
+  - name: commcarehq_ucr
+    django_alias: ucr
+    django_migrate: False
+  - name: "{{ localsettings.PG_DATABASE_NAME }}"
+    django_alias: default
+  - name: "{{ formplayer_db_name }}"
+
+redis_max_memory: 4096mb
+redis_logfile: '/var/log/redis/redis-server.log'
+redis_syslog_enabled: 'no'
+redis_database_save_times: []
+redis_max_clients: 10000
+redis_maxmemory_policy: allkeys-lru
+
+ECRYPTFS_PASSWORD: "{{ secrets.ECRYPTFS_PASSWORD }}"
+
+KSPLICE_ACTIVE: yes
+KSPLICE_ACTIVATION_KEY: "{{ secrets.KSPLICE_ACTIVATION_KEY }}"
+
+AMQP_USER: "{{ secrets.AMQP_USER }}"
+AMQP_PASSWORD: "{{ secrets.AMQP_PASSWORD }}"
+AMQP_HOST: "185.12.7.167"
+AMQP_NAME: commcarehq
+
+shared_drive_enabled: false
+
+couch_dbs:
+  default:
+    host: 185.12.7.167
+    port: 5984
+    name: commcarehq
+    username: "{{ localsettings_private.COUCH_USERNAME }}"
+    password: "{{ localsettings_private.COUCH_PASSWORD }}"
+    is_https: False
+
+localsettings:
+  ALLOWED_HOSTS:
+    - swiss.commcarehq.org
+    - 185.12.7.167
+    - localhost
+    - 127.0.0.1
+    - testserver
+  BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
+  BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }
+  BANK_NAME: "RBS Citizens N.A."
+  BANK_SWIFT_CODE: 'CTZIUS33'
+  BANK_ROUTING_NUMBER_ACH: "{{ localsettings_private.BANK_ROUTING_NUMBER_ACH }}"
+  BANK_ROUTING_NUMBER_WIRE: "{{ localsettings_private.BANK_ROUTING_NUMBER_WIRE }}"
+  BITLY_APIKEY: "{{ localsettings_private.BITLY_APIKEY }}"
+  BITLY_LOGIN: "{{ localsettings_private.BITLY_LOGIN }}"
+  BOOKKEEPER_CONTACT_EMAILS: "{{ localsettings_private.BOOKKEEPER_CONTACT_EMAILS }}"
+  BROKER_URL: 'amqp://{{ secrets.AMQP_USER }}:{{ secrets.AMQP_PASSWORD }}@{{ AMQP_HOST }}:5672/{{ AMQP_NAME }}'
+  CELERY_FLOWER_URL: "http://{{ groups.celery.0 }}:5555"
+  CELERY_PERIODIC_QUEUE: 'celery_periodic'
+  CELERY_REMINDER_CASE_UPDATE_QUEUE: reminder_case_update_queue
+  CELERY_REMINDER_RULE_QUEUE: reminder_rule_queue
+  CELERY_RESULT_BACKEND: 'djcelery.backends.database:DatabaseBackend'
+  CLOUDCARE_BASE_URL: http://localhost:9010
+  COUCH_CACHE_DOCS: True
+  COUCH_CACHE_VIEWS: True
+  COUCH_PASSWORD: "{{ localsettings_private.COUCH_PASSWORD }}"
+  COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
+# swiss is not hosted by Cloudant
+  COUCH_STALE_QUERY: 'update_after'
+  DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
+#  DROPBOX_APP_NAME:
+#  DROPBOX_KEY:
+#  DROPBOX_SECRET:
+  ELASTICSEARCH_HOST: "localhost"
+  ELASTICSEARCH_PORT: '9200'
+  EMAIL_LOGIN: "{{ localsettings_private.EMAIL_LOGIN }}"
+  EMAIL_PASSWORD: "{{ localsettings_private.EMAIL_PASSWORD }}"
+  EMAIL_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
+  EMAIL_SMTP_PORT: 587
+  EMAIL_USE_TLS: yes
+  FORMPLAYER_URL: "/formplayer"
+  FORMPLAYER_INTERNAL_AUTH_KEY: "{{ localsettings_private.FORMPLAYER_INTERNAL_AUTH_KEY }}"
+  GMAPS_API_KEY: "{{ localsettings_private.GMAPS_API_KEY }}"
+  GOOGLE_ANALYTICS_API_ID: "{{ localsettings_private.GOOGLE_ANALYTICS_API_ID }}"
+  HQ_INSTANCE: 'swiss'
+  HUBSPOT_API_ID:
+  HUBSPOT_API_KEY:
+  INVOICE_FROM_ADDRESS:
+    'name': "Dimagi, Inc."
+    'first_line': "585 Massachusetts Ave"
+    'city': "Cambridge"
+    'region': "MA"
+    'postal_code': "02139"
+    'country': "US"
+    'phone_number': "(617) 649-2214"
+    'email': "accounts@dimagi.com"
+    'website': "http://www.dimagi.com"
+  INVOICE_PREFIX: INC-
+  INVOICE_STARTING_NUMBER: 5000
+  JAR_KEY_ALIAS: javarosakey
+  JAR_KEY_PASS: "{{ localsettings_private.JAR_KEY_PASS }}"
+  JAR_STORE_PASS: "{{ localsettings_private.JAR_STORE_PASS }}"
+  J2ME_ADDRESS: ''
+#  KAFKA_HOST:
+  KISSMETRICS_KEY:
+  MAPS_LAYERS: "{{ localsettings_private.MAPS_LAYERS }}"
+  MIA_THE_DEPLOY_BOT_API: "{{ localsettings_private.MIA_THE_DEPLOY_BOT_API }}"
+  OPEN_EXCHANGE_RATES_API_ID: "{{ localsettings_private.OPEN_EXCHANGE_RATES_API_ID }}"
+  PG_DATABASE_HOST: "127.0.0.1"
+  PG_DATABASE_NAME: commcarehq
+  PG_DATABASE_PASSWORD: "{{ secrets.POSTGRES_USERS.commcare.password }}"
+  PG_DATABASE_USER: "{{ secrets.POSTGRES_USERS.commcare.username }}"
+  PG_DATABASE_PORT: 6432
+#  PILLOWTOP_MACHINE_ID:
+  PILLOW_RETRY_QUEUE_ENABLED: True
+  REDIS_DB: '0'
+  REDIS_HOST: "localhost"
+  REDIS_PORT: '6379'
+  REMINDERS_QUEUE_ENABLED: False
+  REPORTING_DATABASES:
+    ucr: ucr
+  SECRET_KEY: "{{ localsettings_private.SECRET_KEY }}"
+  SIMPLE_API_KEYS:
+  SENTRY_PUBLIC_KEY: "{{ localsettings_private.SENTRY_PUBLIC_KEY }}"
+  SENTRY_PRIVATE_KEY: "{{ localsettings_private.SENTRY_PRIVATE_KEY }}"
+  SENTRY_PROJECT_ID: "{{ localsettings_private.SENTRY_PROJECT_ID }}"
+  SENTRY_QUERY_URL: "{{ localsettings_private.SENTRY_QUERY_URL }}"
+  SENTRY_API_KEY: "{{ localsettings_private.SENTRY_API_KEY }}"
+  SMS_GATEWAY_PARAMS: "{{ localsettings_private.SMS_GATEWAY_PARAMS }}"
+  SMS_GATEWAY_URL: 'http://gw1.promessaging.com/sms.php'
+  SMS_QUEUE_ENABLED: False
+#  STATIC_ROOT:
+#  STRIPE_PRIVATE_KEY:
+#  STRIPE_PUBLIC_KEY:
+  TOUCHFORMS_API_PASSWORD: "{{ localsettings_private.TOUCHFORMS_API_PASSWORD }}"
+  TOUCHFORMS_API_USER: "{{ localsettings_private.TOUCHFORMS_API_USER }}"
+  XFORMS_PLAYER_URL: "http://127.0.0.1:4444/"

--- a/environments/swiss/public.yml
+++ b/environments/swiss/public.yml
@@ -4,9 +4,6 @@ NO_WWW_SITE_HOST: 'swiss.commcarehq.org'
 deploy_env: swiss
 
 active_sites:
-  cchq_ssl: True
-  cchq_www_redirect_secure: True
-  cchq_http: True
   cchq_http_j2me: False
   cchq_www_redirect_insecure: False
   commtrack_ssl: False


### PR DESCRIPTION
This is a work in progress, but I thought I'd open up the approach for comment. The goal is to add a file `environmental-defaults/public.yml` that the other `public.yml` conceptually inherit from. (It inherits recursively so that `localsettings.ALLOWED_HOSTS` gets the parent value, rather than `localsettings` being blown over entirely.)

The approach here is to leave the code in an intermediate situation where each environment has a `public.yml` and an `expected-public.yml`. Running `./commcare-cloud/tests/test_vars.sh` checks that the defaults + `public.yml` = `expected-public.yml`, printing out

```
enikshay
✓ OK
icds
✓ OK
icds-new
✓ OK
l10k
✓ OK
pna
✓ OK
production
✓ OK
softlayer
✓ OK
staging
✓ OK
swiss
✓ OK
```

(or a diff if the end-values differ). That test is run by travis. It's also _super_ useful when converting repeated variables to default variables—you can prove to yourself nothing changed.

I wouldn't want to merge this before doing more work to pull out identical variables (I think there are tons) and leaving this in a better state, but I'm mostly interested to hear whether people would find that end-state valuable, or if you think another approach is better. Tell me what you think. This will be easiest to review commit by commit.