### PR TITLE
remove ap and aps control machine aliases

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -32,8 +32,6 @@ wait
 # convenience: . init-ansible
 [ ! -f ~/init-ansible ] && ln -s ~/commcarehq-ansible/control/init.sh ~/init-ansible
 ~/commcarehq-ansible/control/check_install.sh
-alias ap='ansible-playbook -u ansible -i ~/commcarehq-ansible/fab/fab/inventory/$ENV -e "@vars/$ENV/${ENV}_vault.yml" -e "@vars/$ENV/${ENV}_public.yml" --ask-vault-pass'
-alias aps='ap deploy_stack.yml'
 alias update-code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 alias update_code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 


### PR DESCRIPTION
if these are not out of date already, they soon will be. I think it is overall dangerous to keep these around much longer