### PR TITLE
make enter after [y/N] a negative answer

### DIFF
--- a/commcare-cloud/commcare_cloud/commcare_cloud.py
+++ b/commcare-cloud/commcare_cloud/commcare_cloud.py
@@ -38,7 +38,7 @@ def ask(message, strict=False, quiet=False):
     if quiet:
         return True
     yesno = 'YES/NO' if strict else 'y/N'
-    negatives = ('NO', 'N', 'n', 'no')
+    negatives = ('NO', 'N', 'n', 'no', '')
     affirmatives = ('YES',) if strict else ('y', 'Y', 'yes')
     acceptable_options = affirmatives + negatives
 


### PR DESCRIPTION
since capital N in [y/N] by convention means no is the default

Fixes #1237
  