### PR TITLE
just source .bash_completion on control machine

### DIFF
--- a/control/init.sh
+++ b/control/init.sh
@@ -37,9 +37,8 @@ alias aps='ap deploy_stack.yml'
 alias update-code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 alias update_code='~/commcarehq-ansible/control/update_code.sh && . ~/init-ansible'
 
-[ ! -f ~/.bash_completion ] && source  ~/commcarehq-ansible/control/.bash_completion
-cp ~/commcarehq-ansible/control/.bash_completion ~/
 PATH=$PATH:~/.commcare-cloud/bin
+source ~/.commcare-cloud/repo/control/.bash_completion
 
 function ae() {
     ansible $1 -m shell -a "$2" -u ansible -i ~/commcarehq-ansible/fab/fab/inventory/$ENV


### PR DESCRIPTION
rather than overwriting ~/.bash_completion

following up on: https://github.com/dimagi/commcarehq-ansible/pull/1242#pullrequestreview-87239064