### PR TITLE
Turn on analytics debug flag on staging

### DIFF
--- a/environments/staging/public.yml
+++ b/environments/staging/public.yml
@@ -141,7 +141,7 @@ localsettings:
     - localhost
     - 127.0.0.1
     - testserver
-  ANALYTICS_DEBUG: False
+  ANALYTICS_DEBUG: True
   ANALYTICS_LOG_LEVEL: "debug"
   BANK_ACCOUNT_NUMBER: "{{ localsettings_private.BANK_ACCOUNT_NUMBER }}"
   BANK_ADDRESS: { 'first_line': "1 Citizens Drive", 'city': "Riverside", 'region': "RI", 'postal_code': "02915" }


### PR DESCRIPTION
Don't know why I set this to `False` in https://github.com/dimagi/commcarehq-ansible/pull/1132 ...can't test analytics on staging if debug is off.

Verified that the staging vault contains staging-specific keys for google and kissmetrics, and no key for hubspot, so we don't send staging data to real services.

@calellowitz 