### PR TITLE
Reduce docs to queue

### DIFF
--- a/environments/icds-new/public.yml
+++ b/environments/icds-new/public.yml
@@ -271,7 +271,7 @@ localsettings:
     - '{{ CAS_SITE_HOST }}'
     - '{{ hostvars[groups.proxy.0].public_ip }}'
 
-  ASYNC_INDICATORS_TO_QUEUE: 120000
+  ASYNC_INDICATORS_TO_QUEUE: 60000
   ASYNC_INDICATOR_QUEUE_CRONTAB:
     minute: '*/5'
     hour: '0-9,16-23'


### PR DESCRIPTION
@czue I'm not running into the same issue you guys were running into where docs weren't being processed. I think we should turn this down because we're queueing a lot more now that  the related doc rebuilding ( https://github.com/dimagi/commcare-hq/pull/18843 ) has been merged

@nickpell 