### PR TITLE
Fixed ASYNC_INDICATOR_QUEUE_TIMES in localsettings.

### DIFF
--- a/ansible/roles/commcarehq/templates/localsettings.py.j2
+++ b/ansible/roles/commcarehq/templates/localsettings.py.j2
@@ -712,7 +712,7 @@ ASYNC_INDICATOR_QUEUE_CRONTAB = crontab(**{{ localsettings.get('ASYNC_INDICATOR_
 {% endif %}
 
 {% if localsettings.get('ASYNC_INDICATOR_QUEUE_TIMES') %}
-ASYNC_INDICATOR_QUEUE_TIMES = crontab(**{{ localsettings.get('ASYNC_INDICATOR_QUEUE_TIMES') }})
+ASYNC_INDICATOR_QUEUE_TIMES = {{ localsettings.get('ASYNC_INDICATOR_QUEUE_TIMES') }}
 {% endif %}
 
 {% if 'MAX_RULE_UPDATES_IN_ONE_RUN' in localsettings %}


### PR DESCRIPTION
Just realized that the original PR was wrong when I was trying to deploy it. We don't want to wrap this in crontab anymore since it's not directly passed to the celery task decorator

@czue @nickpell 