### PR TITLE
fix postfix config

### DIFF
--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -10,7 +10,6 @@
         line: "relay_transport = error"
         state: absent
       notify: restart postfix
-  handlers:
     - name: "no error for mail transport"
       lineinfile:
         dest: /etc/postfix/main.cf

--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -4,6 +4,12 @@
   tasks:
     - debconf: name=postfix question="postfix/main_mailer_type" value="Internet Site" vtype="string"
     - apt: name=postfix state=present force=yes
+    - name: "set myhostname in postfix"
+      lineinfile:
+        dest: /etc/postfix/main.cf
+        regexp: '^myhostname ='
+        line: "myhostname = {{ ansible_fqdn }}"
+      notify: restart postfix
     - name: "no error for relay transport"
       lineinfile:
         dest: /etc/postfix/main.cf

--- a/ansible/deploy_mailrelay.yml
+++ b/ansible/deploy_mailrelay.yml
@@ -4,6 +4,22 @@
   tasks:
     - debconf: name=postfix question="postfix/main_mailer_type" value="Internet Site" vtype="string"
     - apt: name=postfix state=present force=yes
+    - name: "no error for relay transport"
+      lineinfile:
+        dest: /etc/postfix/main.cf
+        line: "relay_transport = error"
+        state: absent
+      notify: restart postfix
+  handlers:
+    - name: "no error for mail transport"
+      lineinfile:
+        dest: /etc/postfix/main.cf
+        line: "default_transport = error"
+        state: absent
+      notify: restart postfix
+  handlers:
+    - name: restart postfix
+      service: name=postfix state=restarted
   tags:
     - postfix
 
@@ -22,19 +38,6 @@
         dest: /etc/postfix/main.cf
         regexp: '^mynetworks ='
         line: "mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 {{ groups['all']|sort|join('/32 ') }}"
-      when: groups['mailrelay'] is defined and parent_mailrelay is defined
-    - name: "no error for relay transport"
-      lineinfile:
-        dest: /etc/postfix/main.cf
-        line: "relay_transport = error"
-        state: absent
-      when: groups['mailrelay'] is defined and parent_mailrelay is defined
-      notify: restart postfix
-    - name: "no error for mail transport"
-      lineinfile:
-        dest: /etc/postfix/main.cf
-        line: "default_transport = error"
-        state: absent
       when: groups['mailrelay'] is defined and parent_mailrelay is defined
       notify: restart postfix
     - name: "unbinds from localhost"


### PR DESCRIPTION
postifx doesn't like that all VMs have the same hostname (template), also, some configs default to error.